### PR TITLE
FixJsExport: Add a wrappers when imported by Wasm instance

### DIFF
--- a/llvm/include/llvm/Cheerp/Writer.h
+++ b/llvm/include/llvm/Cheerp/Writer.h
@@ -542,6 +542,20 @@ public:
 		{
 			return t;
 		}
+		bool isFunction() const
+		{
+			return F;
+		}
+		bool returnsSomething() const
+		{
+			assert(isFunction());
+			return !(F->getReturnType()->isVoidTy());
+		}
+		uint32_t getNumArgs() const
+		{
+			assert(isFunction());
+			return F->arg_size();
+		}
 	};
 	static std::deque<JSExportedNamedDecl> buildJsExportedNamedDecl(const llvm::Module& M);
 	static void prependRootToNames(std::deque<CheerpWriter::JSExportedNamedDecl> & exportedDecls);


### PR DESCRIPTION
Generates something like:
var doComplexStuff=__dummy;
doComplexStuff.w=function(){return doComplexStuff()};

WebAssembly.instantiate(buffer,
{i:{
                __ZN6client14doComplexStuffEi:doComplexStuff.w,
        }})

The .w member wraps to a call of the original function (set to DUMMY)
then when the function is reassigned to the implementation function
(after the Wasm has been instantiated asyncronously) the module will
keel calling through this wrapper function.

It's contrived, but seems to abide by the WebAssembly specs / its'
supported by all JS engines.

Previously the problem was that the import would never be reassigned,
and so DUMMY would be called instead.