### PR TITLE
InvokeWrapping: Remove sret attribute from wrapped invokes

### DIFF
--- a/llvm/lib/CheerpUtils/InvokeWrapping.cpp
+++ b/llvm/lib/CheerpUtils/InvokeWrapping.cpp
@@ -36,11 +36,8 @@ static CallInst* replaceInvokeWithWrapper(InvokeInst* IV, Function* Wrapper, Arr
 	AttributeList OldAttrs = IV->getAttributes();
 
 	// Clone any argument attributes
-	int i = 0;
-	for (const llvm::Use &OldArg : IV->args()) {
-		NewArgAttrs[i+2] =
-		OldAttrs.getParamAttrs(i);
-		i++;
+	for (uint32_t i = 0; i < IV->arg_size(); i++) {
+		NewArgAttrs[i+2] = OldAttrs.getParamAttrs(i).removeAttribute(IV->getContext(), Attribute::StructRet);
 	}
 
 	NewCall->setAttributes(


### PR DESCRIPTION
The sret attribute can only appear in the first two arguments, but
InvokeInvokeWrapping shifts all arguments by one or two positions.
Since we don't really have a use for sret in llc, just drop it if
present.