### PR TITLE
Exceptions: Fix an issue with Resume and DeadStoreElimination

### DIFF
--- a/llvm/lib/Analysis/AliasAnalysis.cpp
+++ b/llvm/lib/Analysis/AliasAnalysis.cpp
@@ -703,6 +703,8 @@ ModRefInfo AAResults::getModRefInfo(const Instruction *I,
     return getModRefInfo((const CatchPadInst *)I, Loc, AAQIP);
   case Instruction::CatchRet:
     return getModRefInfo((const CatchReturnInst *)I, Loc, AAQIP);
+  case Instruction::Resume:
+    return ModRefInfo::MustModRef;
   default:
     return ModRefInfo::NoModRef;
   }

--- a/llvm/lib/IR/Instruction.cpp
+++ b/llvm/lib/IR/Instruction.cpp
@@ -571,6 +571,7 @@ bool Instruction::mayReadFromMemory() const {
   case Instruction::AtomicRMW:
   case Instruction::CatchPad:
   case Instruction::CatchRet:
+  case Instruction::Resume:
     return true;
   case Instruction::Call:
   case Instruction::Invoke:


### PR DESCRIPTION
Our Resume takes a pointer to a stack-allocated __cheerp_landingpad as
argument, instead of an aggregate like in upstream.
But Resume is not marked as potentially reading the memory pointed by
its argument, so DSE can remove the store that initializes it.
The proper solution will be implementing aggregates in the backend, but
for now we are signaling that Resume can read memory.