### PR TITLE
Writer: Fix a priority issue in asm.js

### DIFF
--- a/llvm/lib/CheerpWriter/CheerpWriter.cpp
+++ b/llvm/lib/CheerpWriter/CheerpWriter.cpp
@@ -4452,7 +4452,7 @@ CheerpWriter::COMPILE_INSTRUCTION_FEEDBACK CheerpWriter::compileCallInstruction(
 		{
 			stream << namegen.getBuiltinName(NameGenerator::Builtin::FROUND) << '(';
 		}
-		else if(kind == Registerize::INTEGER && parentPrio > BIT_OR)
+		else if(kind == Registerize::INTEGER && parentPrio >= BIT_OR)
 		{
 			stream << '(';
 		}
@@ -4463,7 +4463,7 @@ CheerpWriter::COMPILE_INSTRUCTION_FEEDBACK CheerpWriter::compileCallInstruction(
 		if(cf!=COMPILE_UNSUPPORTED)
 		{
 			if (!retTy->isVectorTy() && (
-				(kind == Registerize::INTEGER && parentPrio > BIT_OR) ||
+				(kind == Registerize::INTEGER && parentPrio >= BIT_OR) ||
 				kind == Registerize::FLOAT))
 			{
 				stream << ')';
@@ -4480,7 +4480,7 @@ CheerpWriter::COMPILE_INSTRUCTION_FEEDBACK CheerpWriter::compileCallInstruction(
 		{
 			case Registerize::INTEGER:
 				stream << "|0";
-				if(parentPrio > BIT_OR)
+				if(parentPrio >= BIT_OR)
 					stream << ')';
 				break;
 			case Registerize::INTEGER64:
@@ -4540,7 +4540,7 @@ CheerpWriter::COMPILE_INSTRUCTION_FEEDBACK CheerpWriter::compileCallInstruction(
 		{
 			case Registerize::INTEGER:
 				stream << "|0";
-				if(parentPrio > BIT_OR)
+				if(parentPrio >= BIT_OR)
 					stream << ')';
 				break;
 			case Registerize::INTEGER64:


### PR DESCRIPTION
When adding |0 after a call in asm,js, put parentheses when the parent
priority is >= BIT_OR, not just >. Otherwise something like:
```
expr | call() | 0
```
does not validate, because `expr | call()` is executed before `|0`