### PR TITLE
Exceptions: Fix invokes with i64 arguments.

### DIFF
--- a/llvm/lib/CheerpUtils/TypeOptimizer.cpp
+++ b/llvm/lib/CheerpUtils/TypeOptimizer.cpp
@@ -214,7 +214,9 @@ void TypeOptimizer::gatherAllTypesInfo(const Module& M)
 			{
 				if (Instruction* I = dyn_cast<Instruction>(U.getUser()))
 				{
-					if (I->getParent()->getParent()->getSection() != StringRef("asmjs"))
+					// NOTE: Invokes from wasm mean that we need js wrappers
+					// (see InvokeWrapping), so they count as calls from js
+					if (I->getParent()->getParent()->getSection() != StringRef("asmjs") || isa<InvokeInst>(I))
 					{
 						onlyCalledByWasm = false;
 						break;


### PR DESCRIPTION
Since invokes from wasm need a wrapper, we must consider them as called
from js, and this means that i64s need to be split (Unless BigInt is
enabled)