### PR TITLE
Writer: Fix a corner case of asm.js validation

### DIFF
--- a/llvm/lib/CheerpWriter/CheerpWriter.cpp
+++ b/llvm/lib/CheerpWriter/CheerpWriter.cpp
@@ -4451,6 +4451,8 @@ CheerpWriter::COMPILE_INSTRUCTION_FEEDBACK CheerpWriter::compileCallInstruction(
 		else if(kind == Registerize::FLOAT)
 		{
 			stream << namegen.getBuiltinName(NameGenerator::Builtin::FROUND) << '(';
+			if (asmjs && !asmjsCallee && !(calledFunc && calledFunc->isIntrinsic()))
+				stream << '+';
 		}
 		else if(kind == Registerize::INTEGER && parentPrio > BIT_OR)
 		{


### PR DESCRIPTION
Imports cannot return a float, so we need a `+` between the call and
fround to temporarily coerce to double. This does not apply to stdlib
functions for some reason, hence the check for isIntrinsic.