### PR TITLE
CFGStackifier: fix a corner case in createBrIfs()

### DIFF
--- a/llvm/lib/CheerpWriter/CFGStackifier.cpp
+++ b/llvm/lib/CheerpWriter/CFGStackifier.cpp
@@ -1055,11 +1055,16 @@ void TokenListOptimizer::createBrIfs()
 		Token* Branch = T->getNextNode();
 		if (Branch->getKind() != Token::TK_Branch || Branch->getNextNode() != End)
 			return;
-		bool IsIfNot = T->getKind() == Token::TK_IfNot;
-		Token* BrIf = IsIfNot
-			? Token::createBrIfNot(T->getBB(), Branch->getMatch())
-			: Token::createBrIf(T->getBB(), Branch->getMatch());
-		Tokens.insert(T->getIter(), BrIf);
+		// If End == Branch->getMatch(), the whole IF is useless, so just remove it
+		// without replacement
+		if (End != Branch->getMatch())
+		{
+			bool IsIfNot = T->getKind() == Token::TK_IfNot;
+			Token* BrIf = IsIfNot
+				? Token::createBrIfNot(T->getBB(), Branch->getMatch())
+				: Token::createBrIf(T->getBB(), Branch->getMatch());
+			Tokens.insert(T->getIter(), BrIf);
+		}
 		erase(T);
 		erase(Branch);
 		erase(End);


### PR DESCRIPTION
If the destination of the BRANCH is the end if the IF itself, once we delete the IF and END, the BRANCH will have a dangling destination. Moreover, the whole IF is useless, and should have been removed previously.
To be robust, we handle this case here, and just remove the whole IF.