### PR TITLE
Allow SROA to create value bitcasts in asmjs/wasm functions

### DIFF
--- a/llvm/include/llvm/Cheerp/BitCastLowering.h
+++ b/llvm/include/llvm/Cheerp/BitCastLowering.h
@@ -1,0 +1,35 @@
+//===-- BitCastLowering.h - Cheerp helper -------------------------===//
+//
+//                     Cheerp: The C++ compiler for the Web
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+// Copyright 2023 Leaning Technologies
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CHEERP_BITCAST_LOWERING_H
+#define CHEERP_BITCAST_LOWERING_H
+
+#include "llvm/IR/PassManager.h"
+
+namespace cheerp{
+
+using namespace llvm;
+
+// This pass lowers bitcasts of scalar values to a store+load from memory.
+// It only runs in asmjs, since genericjs never has these bitcasts (they are
+// disabled in SROA) and Wasm has appropriate instructions to handle them.
+// 64-bit bitcasts are handled separately in I64Lowering, and cheerpBitCastSlot
+// is defined in GDA.
+class BitCastLoweringPass: public llvm::PassInfoMixin<BitCastLoweringPass> {
+
+public:
+	PreservedAnalyses run(llvm::Function& M, FunctionAnalysisManager& FAM);
+	static bool isRequired() { return true;}
+};
+
+}
+
+#endif

--- a/llvm/lib/CheerpUtils/BitCastLowering.cpp
+++ b/llvm/lib/CheerpUtils/BitCastLowering.cpp
@@ -1,0 +1,59 @@
+//===-- BitCastLowering.cpp - Cheerp helper -------------------------===//
+//
+//                     Cheerp: The C++ compiler for the Web
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+// Copyright 2023 Leaning Technologies
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Cheerp/BitCastLowering.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/InstIterator.h"
+#include "llvm/Cheerp/Utility.h"
+
+using namespace llvm;
+
+namespace cheerp
+{
+
+PreservedAnalyses BitCastLoweringPass::run(Function& F, FunctionAnalysisManager& FAM)
+{
+	if (LinearOutput != AsmJs || F.getSection() != "asmjs")
+		return PreservedAnalyses::all();
+
+	bool Changed = false;
+	Value* BitCastSlot = F.getParent()->getGlobalVariable("cheerpBitCastSlot");
+	for(Instruction& I: make_early_inc_range(instructions(F))) 
+	{
+		if (BitCastInst* BI = dyn_cast<BitCastInst>(&I)) {
+			Type* RetTy = BI->getType();
+			Value* Arg = BI->getOperand(0);
+			Type* ArgTy = Arg->getType();
+			if(!RetTy->isFloatingPointTy() && !RetTy->isIntegerTy())
+				continue;
+			if(!ArgTy->isFloatingPointTy() && !ArgTy->isIntegerTy())
+				continue;
+
+			IRBuilder<> Builder(&I);
+
+			Value* CastSrc = Builder.CreateBitCast(BitCastSlot, ArgTy->getPointerTo());
+			Builder.CreateStore(Arg, CastSrc);
+			Value* CastDst = Builder.CreateBitCast(BitCastSlot, RetTy->getPointerTo());
+			Value* Ret = Builder.CreateLoad(RetTy, CastDst);
+
+			I.replaceAllUsesWith(Ret);
+			I.eraseFromParent();
+			Changed = true;
+		}
+	}
+	if (!Changed)
+		return PreservedAnalyses::all(); 
+	PreservedAnalyses PA;
+	PA.preserveSet<CFGAnalyses>();
+	return PA;
+}
+
+}

--- a/llvm/lib/CheerpUtils/CMakeLists.txt
+++ b/llvm/lib/CheerpUtils/CMakeLists.txt
@@ -31,6 +31,7 @@ add_llvm_component_library(LLVMCheerpUtils
   CallConstructors.cpp
   SIMDLowering.cpp
   SIMDTransform.cpp
+  BitCastLowering.cpp
   )
 
 add_dependencies(LLVMCheerpUtils intrinsics_gen)

--- a/llvm/lib/CheerpUtils/Utility.cpp
+++ b/llvm/lib/CheerpUtils/Utility.cpp
@@ -287,7 +287,6 @@ bool InlineableCache::isInlineableImpl(const Instruction& I)
 	{
 		if (!I.getType()->isPointerTy())
 		{
-			assert(I.getType()->isVectorTy() || I.getOperand(0)->getType()->isVectorTy());
 			return !hasMoreThan1Use || !isa<Instruction>(I.getOperand(0)) || !isInlineableRecursion(*cast<Instruction>(I.getOperand(0)));
 		}
 		POINTER_KIND IPointerKind = PA.getPointerKind(&I);
@@ -1147,7 +1146,7 @@ const Instruction* getUniqueIncomingInst(const Value* v, const PointerAnalyzer& 
 			return I;
 		else if(I->getOpcode() == Instruction::Trunc)
 			v = I->getOperand(0);
-		else if(I->getOpcode() == Instruction::BitCast && PA.getPointerKind(I) == RAW)
+		else if(I->getOpcode() == Instruction::BitCast && I->getType()->isPointerTy() && PA.getPointerKind(I) == RAW)
 		{
 			// TODO: Expand this logic to support other cases where a bitcast is a nop (when no kind conversion is required?)
 			v = I->getOperand(0);

--- a/llvm/lib/CheerpWriter/CheerpWasmWriter.cpp
+++ b/llvm/lib/CheerpWriter/CheerpWasmWriter.cpp
@@ -2088,7 +2088,33 @@ bool CheerpWasmWriter::compileInlineInstruction(WasmBuffer& code, const Instruct
 			}
 			else if (I.getOperand(0)->getType()->isVectorTy())
 				assert(false && "Bitcasting from vector to integer not supported yet");
-			compileOperand(code, I.getOperand(0));
+			Value* operand = I.getOperand(0);
+			compileOperand(code, operand);
+			if(I.getType()->isIntegerTy())
+			{
+				uint32_t bitWidth = I.getType()->getIntegerBitWidth();
+				if(bitWidth == 32)
+				{
+					assert(operand->getType()->isFloatTy());
+					encodeInst(WasmOpcode::I32_REINTERPRET_F32, code);
+				}
+				else
+				{
+					assert(bitWidth == 64);
+					assert(operand->getType()->isDoubleTy());
+					encodeInst(WasmOpcode::I64_REINTERPRET_F64, code);
+				}
+			}
+			else if(I.getType()->isFloatTy())
+			{
+				assert(operand->getType()->isIntegerTy(32));
+				encodeInst(WasmOpcode::F32_REINTERPRET_I32, code);
+			}
+			else if(I.getType()->isDoubleTy())
+			{
+				assert(operand->getType()->isIntegerTy(64));
+				encodeInst(WasmOpcode::F64_REINTERPRET_I64, code);
+			}
 			break;
 		}
 		case Instruction::Br:

--- a/llvm/lib/Transforms/Scalar/SROA.cpp
+++ b/llvm/lib/Transforms/Scalar/SROA.cpp
@@ -703,7 +703,7 @@ private:
     if (BC.use_empty())
       return markAsDead(BC);
 
-    if (!DL.isByteAddressable()) {
+    if (!DL.isByteAddressable() && BC.getParent()->getParent()->getSection() != StringRef("asmjs")) {
       // Do not handle unions. This limitation may be removed by having a global temporary DataView
       if(AllocaTy->isStructTy() && cast<StructType>(AllocaTy)->hasByteLayout())
         return PI.setAborted(&BC);


### PR DESCRIPTION
For asmjs these bitcasts are then lowered to use memory again. A new BitCastLowering pass takes care of the common case, while i64s are handled in I64Lowering.

TODO: Enable also for genericjs by using a bytelayout slot.