### PR TITLE
Add a standalone target to produce a single wasm file

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -688,7 +688,8 @@ static llvm::Triple computeTargetTriple(const Driver &D,
 
   if (Target.getArch() == llvm::Triple::cheerp)
   {
-    Target.setOS(llvm::Triple::WebBrowser);
+    if (Target.getOS() == llvm::Triple::UnknownOS)
+      Target.setOS(llvm::Triple::WebBrowser);
     if (Target.getVendor() == llvm::Triple::UnknownVendor)
       Target.setVendor(llvm::Triple::Leaningtech);
     if (Target.getEnvironment() == llvm::Triple::UnknownEnvironment)
@@ -6013,6 +6014,7 @@ const ToolChain &Driver::getToolChain(const ArgList &Args,
       TC = std::make_unique<toolchains::HLSLToolChain>(*this, Target, Args);
       break;
     case llvm::Triple::WebBrowser:
+    case llvm::Triple::Standalone:
       TC = std::make_unique<toolchains::Cheerp>(*this, Target, Args);
       break;
     default:

--- a/clang/lib/Driver/ToolChains/WebAssembly.cpp
+++ b/clang/lib/Driver/ToolChains/WebAssembly.cpp
@@ -569,7 +569,8 @@ void cheerp::Link::ConstructJob(Compilation &C, const JobAction &JA,
       CmdArgs.push_back(Args.MakeArgString(getToolChain().GetFilePath("libc.bc")));
       CmdArgs.push_back(Args.MakeArgString(getToolChain().GetFilePath("crt1.bc")));
     }
-    CmdArgs.push_back(Args.MakeArgString(getToolChain().GetFilePath("libsystem.bc")));
+    if (getToolChain().getTriple().getOS() != llvm::Triple::Standalone)
+      CmdArgs.push_back(Args.MakeArgString(getToolChain().GetFilePath("libsystem.bc")));
 
     // Add wasm helper if needed
     Arg *CheerpLinearOutput = Args.getLastArg(options::OPT_cheerp_linear_output_EQ);
@@ -791,6 +792,7 @@ void cheerp::CheerpCompiler::ConstructJob(Compilation &C, const JobAction &JA,
   }
 
   llvm::Triple::EnvironmentType env = getToolChain().getTriple().getEnvironment();
+  llvm::Triple::OSType os = getToolChain().getTriple().getOS();
   Arg* cheerpLinearOutput = Args.getLastArg(options::OPT_cheerp_linear_output_EQ);
   if (cheerpLinearOutput)
     cheerpLinearOutput->render(Args, CmdArgs);
@@ -813,7 +815,7 @@ void cheerp::CheerpCompiler::ConstructJob(Compilation &C, const JobAction &JA,
   if(Arg* cheerpSecondaryOutputFile = Args.getLastArg(options::OPT_cheerp_secondary_output_file_EQ))
     cheerpSecondaryOutputFile->render(Args, CmdArgs);
   else if(
-      ((env == llvm::Triple::WebAssembly && !cheerpLinearOutput) ||
+      ((env == llvm::Triple::WebAssembly && os != llvm::Triple::Standalone && !cheerpLinearOutput) ||
         (cheerpLinearOutput && cheerpLinearOutput->getValue() != StringRef("asmjs"))))
   {
     SmallString<64> path(Output.getFilename());

--- a/clang/lib/Lex/InitHeaderSearch.cpp
+++ b/clang/lib/Lex/InitHeaderSearch.cpp
@@ -417,6 +417,7 @@ bool InitHeaderSearch::ShouldAddDefaultIncludePaths(
   case llvm::Triple::OpenBSD:
   case llvm::Triple::Solaris:
   case llvm::Triple::WASI:
+  case llvm::Triple::Standalone:
   case llvm::Triple::WebBrowser:
     return false;
 

--- a/llvm/include/llvm/ADT/Triple.h
+++ b/llvm/include/llvm/ADT/Triple.h
@@ -224,6 +224,7 @@ public:
     WASI,       // Experimental WebAssembly OS
     Emscripten,
     ShaderModel, // DirectX ShaderModel
+    Standalone,
     WebBrowser,
     LastOSType = WebBrowser
   };

--- a/llvm/include/llvm/Cheerp/GlobalDepsAnalyzer.h
+++ b/llvm/include/llvm/Cheerp/GlobalDepsAnalyzer.h
@@ -52,7 +52,7 @@ public:
 	typedef llvm::SmallVector<const llvm::Use *, 8> SubExprVec;
 	typedef std::unordered_multimap< const llvm::GlobalVariable *, SubExprVec > FixupMap;
 
-	GlobalDepsAnalyzer(MATH_MODE mathMode = NO_BUILTINS, bool llcPass = false, bool wasmStart = false);
+	GlobalDepsAnalyzer(MATH_MODE mathMode = NO_BUILTINS, bool llcPass = false);
 	
 	/**
 	 * Determine if a given global value is reachable
@@ -274,7 +274,6 @@ private:
 	bool mayNeedAsmJSFree;
 
 	bool llcPass;
-	bool wasmStart;
 	bool hasUndefinedSymbolErrors;
 public:
 	bool forceTypedArrays;
@@ -299,7 +298,6 @@ struct GlobalDepsInitializer
 {
 	cheerp::GlobalDepsAnalyzer::MATH_MODE mathMode;
 	bool resolveAliases;
-	bool WasmOnly;
 };
 
 
@@ -310,7 +308,7 @@ public:
 	{
 		if (innerPtr)
 			delete innerPtr;
-		innerPtr = new GlobalDepsAnalyzer(data.mathMode, data.resolveAliases, data.WasmOnly);
+		innerPtr = new GlobalDepsAnalyzer(data.mathMode, data.resolveAliases);
 		innerPtr->MAM = &MAM;
 		return *innerPtr;
 	}
@@ -330,7 +328,7 @@ class GlobalDepsAnalyzerPass : public llvm::PassInfoMixin<GlobalDepsAnalyzerPass
 	GlobalDepsInitializer data;
 public:
 	llvm::PreservedAnalyses run(llvm::Module &M, llvm::ModuleAnalysisManager&);
-	GlobalDepsAnalyzerPass(GlobalDepsAnalyzer::MATH_MODE mathMode=GlobalDepsAnalyzer::MATH_MODE::NO_BUILTINS, bool llcPass = false, bool wasmStart = false) : data({mathMode, llcPass, wasmStart}) {}
+	GlobalDepsAnalyzerPass(GlobalDepsAnalyzer::MATH_MODE mathMode=GlobalDepsAnalyzer::MATH_MODE::NO_BUILTINS, bool llcPass = false) : data({mathMode, llcPass}) {}
 	static bool isRequired() { return true; }
 };
 

--- a/llvm/include/llvm/Cheerp/LinearMemoryHelper.h
+++ b/llvm/include/llvm/Cheerp/LinearMemoryHelper.h
@@ -34,7 +34,6 @@ struct LinearMemoryHelperInitializer
 	FunctionAddressMode mode;
 	uint32_t memorySize;
 	uint32_t stackSize;
-	bool wasmOnly;
 	bool growMem;
 };
 
@@ -177,7 +176,7 @@ public:
 		mode(data.mode), functionTables(3, FunctionSignatureHash(/*isStrict*/false), FunctionSignatureCmp(/*isStrict*/false)),
 		functionTypeIndices(3, FunctionSignatureHash(/*isStrict*/false), FunctionSignatureCmp(/*isStrict*/false)),
 		maxFunctionId(0), memorySize(data.memorySize*1024*1024),
-		stackSize(data.stackSize*1024*1024), wasmOnly(data.wasmOnly), growMem(data.growMem)
+		stackSize(data.stackSize*1024*1024), growMem(data.growMem)
 	{
 	}
 	bool runOnModule(llvm::Module& module, GlobalDepsAnalyzer* GDA)
@@ -385,8 +384,6 @@ private:
 	uint32_t stackSize;
 	// Stack start (it grows downwards)
 	uint32_t stackStart;
-	// We are producing a standalone wasm module
-	bool wasmOnly;
 	// Whether memory can grow at runtime or not
 	bool growMem;
 	llvm::ModuleAnalysisManager* MAM;

--- a/llvm/include/llvm/Cheerp/WasmWriter.h
+++ b/llvm/include/llvm/Cheerp/WasmWriter.h
@@ -110,8 +110,8 @@ private:
 	uint32_t heapSize;
 
 	// If true, the Wasm file is loaded using a JavaScript loader. This allows
-	// FFI calls to methods outside of the Wasm file. When false, write
-	// opcode 'unreachable' for calls to unknown functions.
+	// FFI calls to methods outside of the Wasm file. When false, treat functions
+	// without a definition as imports.
 	bool useWasmLoader;
 
 	// If true, embed a custom section called 'name' in binary wasm that maps
@@ -373,7 +373,6 @@ private:
 	void compileTableSection();
 	void compileMemoryAndGlobalSection();
 	void compileExportSection();
-	void compileStartSection();
 	void compileElementSection();
 	void compileCodeSection();
 	void compileDataSection();

--- a/llvm/lib/CheerpUtils/CallConstructors.cpp
+++ b/llvm/lib/CheerpUtils/CallConstructors.cpp
@@ -16,6 +16,7 @@
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/IRBuilder.h"
+#include "llvm/ADT/Triple.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Pass.h"
 
@@ -33,6 +34,9 @@ PreservedAnalyses CallConstructorsPass::run(llvm::Module &M, llvm::ModuleAnalysi
 	if (!Ctors->empty())
 		return PreservedAnalyses::all();
 
+	bool Standalone = Triple(M.getTargetTriple()).getOS() == Triple::Standalone;
+	if (Standalone)
+		Ctors->setSection("asmjs");
 	BasicBlock* Entry = BasicBlock::Create(M.getContext(),"entry", Ctors);
 	IRBuilder<> Builder(Entry);
 

--- a/llvm/lib/CheerpUtils/CommandLine.cpp
+++ b/llvm/lib/CheerpUtils/CommandLine.cpp
@@ -22,8 +22,6 @@ llvm::cl::opt<std::string> SourceMapPrefix("cheerp-sourcemap-prefix", llvm::cl::
 
 llvm::cl::opt<std::string> MakeModule("cheerp-make-module", llvm::cl::Optional, llvm::cl::desc("Create a [closure/commonjs] module around the generated code.") );
 
-llvm::cl::opt<bool> WasmOnly("cheerp-wasm-only", llvm::cl::desc("Generate only the wasm module without the genericjs functions and the JS glue code") );
-
 llvm::cl::opt<bool> SourceMapStandAlone("cheerp-sourcemap-standalone", llvm::cl::desc("Generate a standalone sourcemap by including _all_ sources in the map file") );
 
 llvm::cl::opt<bool> PrettyCode("cheerp-pretty-code", llvm::cl::desc("Generate human-readable JS") );

--- a/llvm/lib/CheerpUtils/GlobalDepsAnalyzer.cpp
+++ b/llvm/lib/CheerpUtils/GlobalDepsAnalyzer.cpp
@@ -38,11 +38,11 @@ using namespace std;
 
 const char* wasmNullptrName = "__wasm_nullptr";
 
-GlobalDepsAnalyzer::GlobalDepsAnalyzer(MATH_MODE mathMode_, bool llcPass, bool wasmStart)
+GlobalDepsAnalyzer::GlobalDepsAnalyzer(MATH_MODE mathMode_, bool llcPass)
 	: hasBuiltin{{false}}, mathMode(mathMode_), DL(NULL),
 	  entryPoint(NULL), hasCreateClosureUsers(false), hasVAArgs(false),
 	  hasPointerArrays(false), hasAsmJSCode(false), hasAsmJSMemory(false), hasAsmJSMalloc(false),
-	  hasCheerpException(false), mayNeedAsmJSFree(false), llcPass(llcPass), wasmStart(wasmStart),
+	  hasCheerpException(false), mayNeedAsmJSFree(false), llcPass(llcPass),
 	  hasUndefinedSymbolErrors(false), forceTypedArrays(false)
 {
 }

--- a/llvm/lib/CheerpUtils/LinearMemoryHelper.cpp
+++ b/llvm/lib/CheerpUtils/LinearMemoryHelper.cpp
@@ -516,7 +516,6 @@ void LinearMemoryHelper::addFunctions()
 
 	// Add the asm.js imports to the function type list. The non-imported
 	// asm.js functions will be added below.
-	if (!wasmOnly) {
 #define ADD_FUNCTION_TYPE(fTy) \
 if (!functionTypeIndices.count(fTy)) { \
 	uint32_t idx = functionTypeIndices.size(); \
@@ -526,46 +525,45 @@ if (!functionTypeIndices.count(fTy)) { \
 }
 #define ADD_BUILTIN(x, sig) if(globalDeps->needsBuiltin(BuiltinInstr::BUILTIN::x)) { needs_ ## sig = true; builtinIds[BuiltinInstr::x] = maxFunctionId++; }
 
-		for (const Function* F : globalDeps->asmJSImports()) {
-			const FunctionType* fTy = F->getFunctionType();
-			ADD_FUNCTION_TYPE(fTy);
-			functionIds.insert(std::make_pair(F, maxFunctionId++));
-		}
-		if(!NoNativeJavaScriptMath && mode == FunctionAddressMode::Wasm)
-		{
-			// Synthetize the function type for float/double builtins
-			Type* f64 = Type::getDoubleTy(module->getContext());
-			Type* f64_1[] = { f64 };
-			Type* f64_2[] = { f64, f64 };
-			FunctionType* f64_f64_1 = FunctionType::get(f64, f64_1, false);
-			FunctionType* f64_f64_2 = FunctionType::get(f64, f64_2, false);
-			bool needs_f64_f64_1 = false;
-			bool needs_f64_f64_2 = false;
-			ADD_BUILTIN(ACOS_F, f64_f64_1);
-			ADD_BUILTIN(ASIN_F, f64_f64_1);
-			ADD_BUILTIN(ATAN_F, f64_f64_1);
-			ADD_BUILTIN(ATAN2_F, f64_f64_2);
-			ADD_BUILTIN(COS_F, f64_f64_1);
-			ADD_BUILTIN(EXP_F, f64_f64_1);
-			ADD_BUILTIN(LOG_F, f64_f64_1);
-			ADD_BUILTIN(POW_F, f64_f64_2);
-			ADD_BUILTIN(SIN_F, f64_f64_1);
-			ADD_BUILTIN(TAN_F, f64_f64_1);
-			if(needs_f64_f64_1)
-				ADD_FUNCTION_TYPE(f64_f64_1);
-			if(needs_f64_f64_2)
-				ADD_FUNCTION_TYPE(f64_f64_2);
-		}
-		Type* i32 = Type::getInt32Ty(module->getContext());
-		Type* i32_1[] = { i32 };
-		FunctionType* i32_i32_1 = FunctionType::get(i32, i32_1, false);
-		bool needs_i32_i32_1 = false;
-		ADD_BUILTIN(GROW_MEM, i32_i32_1);
-		if(needs_i32_i32_1)
-			ADD_FUNCTION_TYPE(i32_i32_1);
+	for (const Function* F : globalDeps->asmJSImports()) {
+		const FunctionType* fTy = F->getFunctionType();
+		ADD_FUNCTION_TYPE(fTy);
+		functionIds.insert(std::make_pair(F, maxFunctionId++));
+	}
+	if(!NoNativeJavaScriptMath && mode == FunctionAddressMode::Wasm)
+	{
+		// Synthetize the function type for float/double builtins
+		Type* f64 = Type::getDoubleTy(module->getContext());
+		Type* f64_1[] = { f64 };
+		Type* f64_2[] = { f64, f64 };
+		FunctionType* f64_f64_1 = FunctionType::get(f64, f64_1, false);
+		FunctionType* f64_f64_2 = FunctionType::get(f64, f64_2, false);
+		bool needs_f64_f64_1 = false;
+		bool needs_f64_f64_2 = false;
+		ADD_BUILTIN(ACOS_F, f64_f64_1);
+		ADD_BUILTIN(ASIN_F, f64_f64_1);
+		ADD_BUILTIN(ATAN_F, f64_f64_1);
+		ADD_BUILTIN(ATAN2_F, f64_f64_2);
+		ADD_BUILTIN(COS_F, f64_f64_1);
+		ADD_BUILTIN(EXP_F, f64_f64_1);
+		ADD_BUILTIN(LOG_F, f64_f64_1);
+		ADD_BUILTIN(POW_F, f64_f64_2);
+		ADD_BUILTIN(SIN_F, f64_f64_1);
+		ADD_BUILTIN(TAN_F, f64_f64_1);
+		if(needs_f64_f64_1)
+			ADD_FUNCTION_TYPE(f64_f64_1);
+		if(needs_f64_f64_2)
+			ADD_FUNCTION_TYPE(f64_f64_2);
+	}
+	Type* i32 = Type::getInt32Ty(module->getContext());
+	Type* i32_1[] = { i32 };
+	FunctionType* i32_i32_1 = FunctionType::get(i32, i32_1, false);
+	bool needs_i32_i32_1 = false;
+	ADD_BUILTIN(GROW_MEM, i32_i32_1);
+	if(needs_i32_i32_1)
+		ADD_FUNCTION_TYPE(i32_i32_1);
 #undef ADD_BUILTIN
 #undef ADD_FUNCTION_TYPE
-	}
 
 	// Check if the __genericjs__free function is present. If so, consider
 	// "free()" as if its address is taken

--- a/llvm/lib/Support/Triple.cpp
+++ b/llvm/lib/Support/Triple.cpp
@@ -244,6 +244,7 @@ StringRef Triple::getOSTypeName(OSType Kind) {
   case Win32: return "windows";
   case ZOS: return "zos";
   case ShaderModel: return "shadermodel";
+  case Standalone: return "standalone";
   case WebBrowser: return "webbrowser";
   }
 
@@ -601,6 +602,7 @@ static Triple::OSType parseOS(StringRef OSName) {
     .StartsWith("wasi", Triple::WASI)
     .StartsWith("emscripten", Triple::Emscripten)
     .StartsWith("shadermodel", Triple::ShaderModel)
+    .StartsWith("standalone", Triple::Standalone)
     .StartsWith("webbrowser", Triple::WebBrowser)
     .Default(Triple::UnknownOS);
 }

--- a/llvm/lib/Target/CheerpBackend/CheerpBackend.cpp
+++ b/llvm/lib/Target/CheerpBackend/CheerpBackend.cpp
@@ -142,7 +142,7 @@ bool CheerpWritePass::runOnModule(Module& M)
   }
 
   MPM.addPass(cheerp::FreeAndDeleteRemovalPass());
-  MPM.addPass(cheerp::GlobalDepsAnalyzerPass(mathMode, /*resolveAliases*/true, WasmOnly));
+  MPM.addPass(cheerp::GlobalDepsAnalyzerPass(mathMode, /*resolveAliases*/true));
   MPM.addPass(cheerp::AllocaLoweringPass());
   MPM.addPass(cheerp::InvokeWrappingPass());
   MPM.addPass(cheerp::FFIWrappingPass());
@@ -155,7 +155,7 @@ bool CheerpWritePass::runOnModule(Module& M)
   // inside not used instructions which are then not rendered.
   MPM.addPass(createModuleToFunctionPassAdaptor(cheerp::PreserveCheerpAnalysisPassWrapper<DCEPass, Function, FunctionAnalysisManager>()));
   MPM.addPass(cheerp::RegisterizePass(!NoJavaScriptMathFround, LinearOutput == Wasm));
-  MPM.addPass(cheerp::LinearMemoryHelperPass(cheerp::LinearMemoryHelperInitializer({functionAddressMode, CheerpHeapSize, CheerpStackSize, WasmOnly, growMem})));
+  MPM.addPass(cheerp::LinearMemoryHelperPass(cheerp::LinearMemoryHelperInitializer({functionAddressMode, CheerpHeapSize, CheerpStackSize, growMem})));
   MPM.addPass(cheerp::ConstantExprLoweringPass());
   MPM.addPass(cheerp::PointerAnalyzerPass());
   MPM.addPass(cheerp::DelayInstsPass());
@@ -211,6 +211,8 @@ PreservedAnalyses cheerp::CheerpWritePassImpl::run(Module& M, ModuleAnalysisMana
   cheerp::reportRegisterizeStatistics();
 #endif
 
+  Triple TargetTriple(M.getTargetTriple());
+  bool WasmOnly = TargetTriple.getOS() == Triple::Standalone;
   std::error_code ErrorCode;
   llvm::ToolOutputFile secondaryFile(SecondaryOutputFile, ErrorCode, sys::fs::OF_None);
   std::unique_ptr<llvm::formatted_raw_ostream> secondaryOut;


### PR DESCRIPTION
The cheerp-leaningtech-standalone-wasm target is similar to the cheerp-leaningtech-webbrowser-wasm but with the following differences:

- No js functions are produced
- No wasm loader logic
- Undefined functions are wasm imports, with their full original name
- JSExported functions are wasm exports, with their jsexported name
- libsystem.bc is not linked
- The _start function is fully in wasm