### PR TITLE
Inherit attribute from base class

### DIFF
--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -13963,6 +13963,7 @@ void Sema::DefineInheritingConstructor(SourceLocation CurrentLocation,
 
   Constructor->setBody(new (Context) CompoundStmt(InitLoc));
   Constructor->markUsed(Context);
+  MaybeInjectCheerpModeAttr(Constructor);
 
   if (ASTMutationListener *L = getASTMutationListener()) {
     L->CompletedImplicitDefinition(Constructor);


### PR DESCRIPTION
For an inherited constructor, a cheerp attribute will now be correctly inherited from the base class.