### PR TITLE
Icf cache fix

### DIFF
--- a/llvm/include/llvm/Cheerp/IdenticalCodeFolding.h
+++ b/llvm/include/llvm/Cheerp/IdenticalCodeFolding.h
@@ -67,6 +67,7 @@ private:
 	llvm::SmallSet<const llvm::PHINode*, 16> visitedPhis;
 	std::unordered_map<std::pair<const llvm::Function*, const llvm::Function*>, bool, pair_hash> functionEquivalence;
 	std::unordered_map<const llvm::Function*, bool> externalFunctionMapping;
+	std::vector<llvm::Function*> deleteList;
 };
 
 class HashAccumulator64 {

--- a/llvm/lib/CheerpUtils/IdenticalCodeFolding.cpp
+++ b/llvm/lib/CheerpUtils/IdenticalCodeFolding.cpp
@@ -986,9 +986,14 @@ bool IdenticalCodeFolding::runOnModule(llvm::Module& module)
 						" to " << replacement->getName() + "_icf" << '\n');
 				replacement->setName(replacement->getName() + "_icf");
 			}
-
-			delete item.first;
 		}
+	}
+
+	for (auto F : deleteList)
+	{
+		F->dropAllReferences();
+		F->removeFromParent();
+		delete F;
 	}
 
 	return true;
@@ -1030,9 +1035,7 @@ void IdenticalCodeFolding::mergeTwoFunctions(Function *F, Function *G) {
 
 		F->replaceAllUsesWith(replacement);
 	}
-	F->dropAllReferences();
-
-	F->removeFromParent();
+	deleteList.push_back(F);
 }
 
 PreservedAnalyses IdenticalCodeFoldingPass::run(Module& M, ModuleAnalysisManager& MAM)

--- a/llvm/lib/CheerpUtils/IdenticalCodeFolding.cpp
+++ b/llvm/lib/CheerpUtils/IdenticalCodeFolding.cpp
@@ -855,7 +855,6 @@ bool IdenticalCodeFolding::isFunctionExternal(const llvm::Function* F)
 	if (it != externalFunctionMapping.end())
 		return it->second;
 
-	bool functionExternal = false;
 	for (const Use& U : F->uses())
 	{
 		const User* user = U.getUser();


### PR DESCRIPTION
This fixes a very rare edgecase in which new instructions created during ICF take the addresses of deleted and already matched functions.