### PR TITLE
Make it possible for malloc,etc. to be a weak alias

### DIFF
--- a/llvm/include/llvm/Cheerp/GlobalDepsAnalyzer.h
+++ b/llvm/include/llvm/Cheerp/GlobalDepsAnalyzer.h
@@ -237,6 +237,8 @@ private:
 	//Pre-process direct calls to possibly simplify them
 	void simplifyCalls(llvm::Module & module) const;
 
+	static void replaceFunctionAliasWithAliasee(llvm::Module &module, llvm::StringRef name);
+
 	//Extend lifetime of function, visiting them and declaring external
 	void extendLifetime(llvm::Function* F);
 


### PR DESCRIPTION
This PR makes it possible for `malloc`,`calloc`,`realloc` and `free` to be weak aliases, which is needed in the future for implementing AddressSanitizer.

I've been trying to do this way to difficult (as can be seen in https://github.com/Hyxogen/cheerp-compiler/tree/fix-weak-alias-history) but only today realized that it could just be easily done like this.

One problem that could arise now though is that if someone 'overrides' one of these functions by defining it themselves, it could result in unexpected behavior if the function has side effects, as the whole function can be optimized out.