### PR TITLE
Move memory allocation from Wasm to js

### DIFF
--- a/llvm/include/llvm/Cheerp/WasmWriter.h
+++ b/llvm/include/llvm/Cheerp/WasmWriter.h
@@ -371,7 +371,7 @@ private:
 	void compileFunctionSection();
 	void compileImportSection();
 	void compileTableSection();
-	void compileMemoryAndGlobalSection();
+	void compileGlobalSection();
 	void compileExportSection();
 	void compileElementSection();
 	void compileCodeSection();
@@ -389,6 +389,7 @@ private:
 	const llvm::BasicBlock* compileTokens(WasmBuffer& code, const TokenList& Tokens);
 	void compileMethod(WasmBuffer& code, const llvm::Function& F);
 	void compileImport(WasmBuffer& code, llvm::StringRef funcName, llvm::FunctionType* FTy);
+	void compileImportMemory(WasmBuffer& code);
 	void compileGlobal(const llvm::GlobalVariable& G);
 	// Returns true if it has handled local assignent internally
 	bool compileInstruction(WasmBuffer& code, const llvm::Instruction& I);

--- a/llvm/include/llvm/Cheerp/Writer.h
+++ b/llvm/include/llvm/Cheerp/Writer.h
@@ -271,8 +271,10 @@ private:
 	bool addCredits;
 	// Flag to signal if we should add code that measures time until main is reached
 	bool measureTimeToMain;
-	// The asm.js module heap size
+	// The wasm or asm.js module heap size
 	uint32_t heapSize;
+	// Whether to disable memory growth
+	bool noGrowMemory;
 	// Flag to signal if we should add bounds-checking code
 	bool checkBounds;
 	// The name of the external wasm file, or empty if not present
@@ -671,6 +673,7 @@ public:
 		addCredits(addCredits),
 		measureTimeToMain(measureTimeToMain),
 		heapSize(heapSize),
+		noGrowMemory(!linearHelper.canGrowMemory()),
 		checkBounds(checkBounds),
 		wasmFile(wasmFile),
 		forceTypedArrays(forceTypedArrays),
@@ -779,6 +782,7 @@ private:
 	void compileCommonJSModule();
 	void compileLoaderOrModuleEnd();
 	void compileDeclareExports();
+	void compileWasmMemory();
 	void compileDefineExports();
 	void compileCommonJSExports();
 	void compileEntryPoint();


### PR DESCRIPTION
Previously, memory was allocated in Wasm and then exported to js. Now, in preparation for threading, we allocate the memory in js and then import it in Wasm.