### PR TITLE
Add mising header

### DIFF
--- a/clang/lib/Headers/cheerpintrin.h
+++ b/clang/lib/Headers/cheerpintrin.h
@@ -12,6 +12,8 @@
 #ifndef __CHEERPINTRIN_H
 #define __CHEERPINTRIN_H
 
+#include <cstddef>
+
 namespace [[cheerp::genericjs]] {
 
 template<class R, class P>


### PR DESCRIPTION
The file `cheerpintrin.h` uses size_t, but the necessary header for it is not included.  