### PR TITLE
Fix wasm loader not properly using supplied buffer

### DIFF
--- a/llvm/lib/CheerpWriter/CheerpWriter.cpp
+++ b/llvm/lib/CheerpWriter/CheerpWriter.cpp
@@ -6120,7 +6120,7 @@ void CheerpWriter::compileFetchBufferCall(const std::string& fileName, const std
 {
 	if (makeModule == MODULE_TYPE::ES6)
 	{
-		stream << "(" << argumentName << "&&" << argumentName << ".buffer)?" << NewLine;
+		stream << "((" << argumentName << "&&" << argumentName << ".buffer)?" << NewLine;
 		stream << "Promise.resolve(" << argumentName << ".buffer):" << NewLine;
 	}
 	stream << namegen.getBuiltinName(NameGenerator::FETCHBUFFER) << "(";
@@ -6135,6 +6135,8 @@ void CheerpWriter::compileFetchBufferCall(const std::string& fileName, const std
 	if (makeModule == MODULE_TYPE::ES6)
 		stream << ", import.meta.url)";
 	stream << ")";
+  if (makeModule == MODULE_TYPE::ES6)
+    stream << ")";
 }
 
 void CheerpWriter::compileSourceMapsBegin()


### PR DESCRIPTION
There was a bug in the wasm loader where, when given a buffer, instead of loading from that buffer it instead just returned the buffer:
```js
import init from "./hello.js";
import { readFile } from "fs";

readFile("hello.wasm", (err, buffer) => {
        init({ buffer }).then((Module) => {
                console.log(Module); // prints <Buffer ...>
        });
});
```
This is because the ternary operator here is not surrounded by parentheses:
```js
return (Lnb&&Lnb.buffer)?
Promise.resolve(Lnb.buffer):
fetchBuffer(/* ... */).then(Lnb=> /* ... */)
```
This PR fixes that by adding an extra set of parentheses around the ternary operator.