### PR TITLE
Addrspace

### DIFF
--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -513,6 +513,8 @@ public:
             (B == LangAS::sycl_private || B == LangAS::sycl_local ||
              B == LangAS::sycl_global || B == LangAS::sycl_global_device ||
              B == LangAS::sycl_global_host)) ||
+           // Cheerp: WIP
+           (A == LangAS::cheerp_client || B == LangAS::cheerp_client) ||
            // In HIP device compilation, any cuda address space is allowed
            // to implicitly cast into the default address space.
            (A == LangAS::Default &&

--- a/clang/include/clang/Basic/AddressSpaces.h
+++ b/clang/include/clang/Basic/AddressSpaces.h
@@ -59,6 +59,9 @@ enum class LangAS : unsigned {
   // HLSL specific address spaces.
   hlsl_groupshared,
 
+  // Cheerp specific address spaces.
+  cheerp_client,
+
   // This denotes the count of language-specific address spaces and also
   // the offset added to the target-specific address spaces, which are usually
   // specified by address space attributes __attribute__(address_space(n))).

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -956,6 +956,7 @@ static const LangASMap *getAddressSpaceMap(const TargetInfo &T,
         11, // ptr32_uptr
         12, // ptr64
         13, // hlsl_groupshared
+        14, // cheerp_client
     };
     return &FakeAddrSpaceMap;
   } else {

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -2689,7 +2689,7 @@ void CXXNameMangler::mangleQualifiers(Qualifiers Quals, const DependentAddressSp
         ASString = "ptr64";
         break;
       case LangAS::cheerp_client:
-        ASString = "client";
+        ASString = "";
         break;
       }
     }

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -2688,6 +2688,9 @@ void CXXNameMangler::mangleQualifiers(Qualifiers Quals, const DependentAddressSp
       case LangAS::ptr64:
         ASString = "ptr64";
         break;
+      case LangAS::cheerp_client:
+        ASString = "client";
+        break;
       }
     }
     if (!ASString.empty())

--- a/clang/lib/AST/TypePrinter.cpp
+++ b/clang/lib/AST/TypePrinter.cpp
@@ -2232,6 +2232,8 @@ std::string Qualifiers::getAddrSpaceAsString(LangAS AS) {
     return "__ptr64";
   case LangAS::hlsl_groupshared:
     return "groupshared";
+  case LangAS::cheerp_client:
+    return "client_as";
   default:
     return std::to_string(toTargetAddressSpace(AS));
   }

--- a/clang/lib/Basic/Targets/AMDGPU.cpp
+++ b/clang/lib/Basic/Targets/AMDGPU.cpp
@@ -57,6 +57,7 @@ const LangASMap AMDGPUTargetInfo::AMDGPUDefIsGenMap = {
     Generic,  // ptr32_uptr
     Generic,  // ptr64
     Generic,  // hlsl_groupshared
+    Generic,  // cheerp_client
 };
 
 const LangASMap AMDGPUTargetInfo::AMDGPUDefIsPrivMap = {
@@ -81,6 +82,7 @@ const LangASMap AMDGPUTargetInfo::AMDGPUDefIsPrivMap = {
     Generic, // ptr32_uptr
     Generic, // ptr64
     Generic, // hlsl_groupshared
+    Generic,  // cheerp_client
 
 };
 } // namespace targets

--- a/clang/lib/Basic/Targets/DirectX.h
+++ b/clang/lib/Basic/Targets/DirectX.h
@@ -42,6 +42,7 @@ static const unsigned DirectXAddrSpaceMap[] = {
     0, // ptr32_uptr
     0, // ptr64
     3, // hlsl_groupshared
+    0, // cheerp_client
 };
 
 class LLVM_LIBRARY_VISIBILITY DirectXTargetInfo : public TargetInfo {

--- a/clang/lib/Basic/Targets/NVPTX.h
+++ b/clang/lib/Basic/Targets/NVPTX.h
@@ -44,6 +44,7 @@ static const unsigned NVPTXAddrSpaceMap[] = {
     0, // ptr32_uptr
     0, // ptr64
     0, // hlsl_groupshared
+    0, // cheerp_client
 };
 
 /// The DWARF address class. Taken from

--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -44,6 +44,7 @@ static const unsigned SPIRDefIsPrivMap[] = {
     0, // ptr32_uptr
     0, // ptr64
     0, // hlsl_groupshared
+    0, // cheerp_client
 };
 
 // Used by both the SPIR and SPIR-V targets.
@@ -74,6 +75,7 @@ static const unsigned SPIRDefIsGenMap[] = {
     0, // ptr32_uptr
     0, // ptr64
     0, // hlsl_groupshared
+    0, // cheerp_client
 };
 
 // Base class for SPIR and SPIR-V target info.

--- a/clang/lib/Basic/Targets/TCE.h
+++ b/clang/lib/Basic/Targets/TCE.h
@@ -51,6 +51,7 @@ static const unsigned TCEOpenCLAddrSpaceMap[] = {
     0, // ptr32_uptr
     0, // ptr64
     0, // hlsl_groupshared
+    0, // cheerp_client
 };
 
 class LLVM_LIBRARY_VISIBILITY TCETargetInfo : public TargetInfo {

--- a/clang/lib/Basic/Targets/WebAssembly.h
+++ b/clang/lib/Basic/Targets/WebAssembly.h
@@ -188,6 +188,30 @@ protected:
                         MacroBuilder &Builder) const override;
 };
 
+static const unsigned CheerpAddrSpaceMap[] = {
+    0,   // Default
+    0,   // opencl_global
+    0,   // opencl_local
+    0,   // opencl_constant
+    0,   // opencl_private
+    0,   // opencl_generic
+    0,   // opencl_global_device
+    0,   // opencl_global_host
+    0,   // cuda_device
+    0,   // cuda_constant
+    0,   // cuda_shared
+    0,   // sycl_global
+    0,   // sycl_global_device
+    0,   // sycl_global_host
+    0,   // sycl_local
+    0,   // sycl_private
+    0, // ptr32_sptr
+    0, // ptr32_uptr
+    0, // ptr64
+    0,   // hlsl_groupshared
+    1,   // cheerp_client
+};
+
 // Cheerp base class
 class CheerpTargetInfo : public TargetInfo {
 private:
@@ -221,6 +245,7 @@ public:
     // We don't have multiple asm variants, and we want to be able to use
     // '{' and '}' in the asm code
     NoAsmVariants = true;
+    AddrSpaceMap = & CheerpAddrSpaceMap;
   }
 
   virtual ArrayRef<Builtin::Info> getTargetBuiltins() const override;

--- a/clang/lib/Basic/Targets/X86.h
+++ b/clang/lib/Basic/Targets/X86.h
@@ -45,6 +45,7 @@ static const unsigned X86AddrSpaceMap[] = {
     271, // ptr32_uptr
     272, // ptr64
     0,   // hlsl_groupshared
+    0,   // cheerp_client
 };
 
 // X86 target abstract base class; x86-32 and x86-64 are very close, so

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -12492,9 +12492,9 @@ Value *CodeGenFunction::EmitCheerpBuiltinExpr(unsigned BuiltinID,
     CallBase* CB = Builder.CreateCall(F, Ops);
 
     llvm::Type* elementType = ConvertTypeForMem(E->getArg(0)->getType()->getPointeeType());
-    assert(Ops[0]->getType()->isOpaquePointerTy() || Ops[0]->getType()->getNonOpaquePointerElementType() == elementType);
-
+    llvm::Type* retType = ConvertType(E->getType()->getPointeeType());
     CB->addParamAttr(0, llvm::Attribute::get(CB->getContext(), llvm::Attribute::ElementType, elementType));
+    CB->addRetAttr(llvm::Attribute::get(CB->getContext(), llvm::Attribute::ElementType, retType));
     return CB;
   }
   else if (BuiltinID == Cheerp::BI__builtin_cheerp_pointer_kind) {

--- a/clang/lib/CodeGen/CGClass.cpp
+++ b/clang/lib/CodeGen/CGClass.cpp
@@ -569,19 +569,19 @@ CodeGenFunction::GenerateDowncast(Address Value,
                                   const CXXRecordDecl *Derived,
                                   llvm::Value* BaseIdOffset)
 {
-  QualType DerivedTy =
-    getContext().getCanonicalType(getContext().getTagDeclType(Derived));
-  llvm::Type *DerivedPtrTy = ConvertType(DerivedTy);
+  llvm::Type *DerivedTy =
+    ConvertType(getContext().getCanonicalType(getContext().getTagDeclType(Derived)));
+  llvm::Type *DerivedPtrTy = DerivedTy->getPointerTo(Value.getAddressSpace());
 
-  llvm::Type* types[] = { DerivedPtrTy->getPointerTo(), Value.getType() };
+  llvm::Type* types[] = { DerivedPtrTy, Value.getType() };
 
   llvm::Function* intrinsic = llvm::Intrinsic::getDeclaration(&CGM.getModule(),
                               llvm::Intrinsic::cheerp_downcast, types);
 
   llvm::CallBase* CB = Builder.CreateCall(intrinsic, {Value.getPointer(), BaseIdOffset});
   CB->addParamAttr(0, llvm::Attribute::get(CB->getContext(), llvm::Attribute::ElementType, Value.getElementType()));
-  CB->addRetAttr(llvm::Attribute::get(CB->getContext(), llvm::Attribute::ElementType, DerivedPtrTy));
-  return Address(CB, DerivedPtrTy, Value.getAlignment());
+  CB->addRetAttr(llvm::Attribute::get(CB->getContext(), llvm::Attribute::ElementType, DerivedTy));
+  return Address(CB, DerivedTy, Value.getAlignment());
 }
 
 llvm::Value *

--- a/clang/lib/CodeGen/CGClass.cpp
+++ b/clang/lib/CodeGen/CGClass.cpp
@@ -580,6 +580,7 @@ CodeGenFunction::GenerateDowncast(Address Value,
 
   llvm::CallBase* CB = Builder.CreateCall(intrinsic, {Value.getPointer(), BaseIdOffset});
   CB->addParamAttr(0, llvm::Attribute::get(CB->getContext(), llvm::Attribute::ElementType, Value.getElementType()));
+  CB->addRetAttr(llvm::Attribute::get(CB->getContext(), llvm::Attribute::ElementType, DerivedPtrTy));
   return Address(CB, DerivedPtrTy, Value.getAlignment());
 }
 

--- a/clang/lib/CodeGen/CGClass.cpp
+++ b/clang/lib/CodeGen/CGClass.cpp
@@ -263,7 +263,7 @@ CodeGenFunction::GetAddressOfDirectBaseInCompleteClass(Address This,
   {
     // Cheerp: if the base class has no members create a bitcast with cheerp specific intrinsic
     if(Base->isEmpty() || Offset.isZero())
-       return GenerateUpcastCollapsed(This, ConvertType(Base), 0);
+       return GenerateUpcastCollapsed(This, ConvertType(Base), This.getAddressSpace());
     else
     {
       // Get the layout.
@@ -551,7 +551,7 @@ CodeGenFunction::GenerateUpcast(Address Value,
   //Cheerp: Check if the type is the expected one. If not create a builtin to handle this.
   //This may happen when empty base classes are used
   if(Value.getType()!=BasePtrTy)
-    Value = GenerateUpcastCollapsed(Value, BasePtrTy, 0);
+    Value = GenerateUpcastCollapsed(Value, BasePtrTy, Value.getAddressSpace());
   return Value;
 }
 

--- a/clang/lib/CodeGen/CGException.cpp
+++ b/clang/lib/CodeGen/CGException.cpp
@@ -417,6 +417,7 @@ void CodeGenFunction::EmitAnyExprToExn(const Expr *e, Address addr) {
     llvm::Function* intrinsic = llvm::Intrinsic::getDeclaration(&CGM.getModule(), llvm::Intrinsic::cheerp_downcast, Tys);
     llvm::CallBase* CB = Builder.CreateCall(intrinsic, {typedAddr.getPointer(), llvm::ConstantInt::get(CGM.Int32Ty, 0)});
     CB->addParamAttr(0, llvm::Attribute::get(CB->getContext(), llvm::Attribute::ElementType, ty));
+    CB->addRetAttr(llvm::Attribute::get(CB->getContext(), llvm::Attribute::ElementType, ty));
     typedAddr = Address(CB, ty, typedAddr.getAlignment());
   }
 

--- a/clang/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/clang/lib/CodeGen/ItaniumCXXABI.cpp
@@ -638,6 +638,7 @@ CGCallee ItaniumCXXABI::EmitLoadOfMemberFunctionPointer(
 
     llvm::CallBase* CB = Builder.CreateCall(intrinsic, {This, Adj});
     CB->addParamAttr(0, llvm::Attribute::get(CB->getContext(), llvm::Attribute::ElementType, ThisAddr.getElementType()));
+    CB->addRetAttr(llvm::Attribute::get(CB->getContext(), llvm::Attribute::ElementType, CGF.Int8Ty));
     llvm::Value* ThisNotZero = Builder.CreateBitCast(CB, This->getType());
     Builder.CreateBr(FnNonVirtual);
     CGF.EmitBlock(FnNonVirtual);
@@ -1659,6 +1660,8 @@ llvm::Value *ItaniumCXXABI::EmitDynamicCastCall(
     llvm::Value* DynamicDowncast = CGF.Builder.CreateCall(intrinsic, {DynCastObj, Value});
     assert(DynCastObj->getType()->isOpaquePointerTy() || DynCastObj->getType()->getNonOpaquePointerElementType() == ThisAddr.getElementType());
     cast<llvm::CallBase>(DynamicDowncast)->addParamAttr(0, llvm::Attribute::get(DynamicDowncast->getContext(), llvm::Attribute::ElementType, ThisAddr.getElementType()));
+    cast<llvm::CallBase>(DynamicDowncast)->addRetAttr(llvm::Attribute::get(DynamicDowncast->getContext(), llvm::Attribute::ElementType, CGF.ConvertType(DestTy->getPointeeType())));
+
     CGF.Builder.CreateBr(EndBB);
     // If the returned offset is zero, we can passthrough the value
     llvm::BasicBlock *ZeroBB = CGF.createBasicBlock("cheerp_null_downcast");

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "clang/Analysis/AnalysisDeclContext.h"
 #include "clang/AST/ASTConsumer.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/ASTLambda.h"
@@ -13667,6 +13668,9 @@ void Sema::setupImplicitSpecialMemberType(CXXMethodDecl *SpecialMem,
   FunctionProtoType::ExtProtoInfo EPI = getImplicitMethodEPI(*this, SpecialMem);
 
   LangAS AS = getDefaultCXXMethodAddrSpace();
+  if (clang::AnalysisDeclContext::isInClientNamespace(SpecialMem->getParent())) {
+    AS = LangAS::cheerp_client;
+  }
   if (AS != LangAS::Default) {
     EPI.TypeQuals.addAddressSpace(AS);
   }

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -3724,6 +3724,7 @@ Sema::ActOnCXXDelete(SourceLocation StartLoc, bool UseGlobal,
     QualType PointeeElem = Context.getBaseElementType(Pointee);
 
     if (Pointee.getAddressSpace() != LangAS::Default &&
+        Context.getTargetInfo().isByteAddressable() &&
         !getLangOpts().OpenCLCPlusPlus)
       return Diag(Ex.get()->getBeginLoc(),
                   diag::err_address_space_qualified_delete)

--- a/clang/lib/Sema/SemaExprCXX.cpp
+++ b/clang/lib/Sema/SemaExprCXX.cpp
@@ -2519,6 +2519,7 @@ bool Sema::CheckAllocatedType(QualType AllocType, SourceLocation Loc,
     return Diag(Loc, diag::err_variably_modified_new_type)
              << AllocType;
   else if (AllocType.getAddressSpace() != LangAS::Default &&
+           Context.getTargetInfo().isByteAddressable() &&
            !getLangOpts().OpenCLCPlusPlus)
     return Diag(Loc, diag::err_address_space_qualified_new)
       << AllocType.getUnqualifiedType()

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -32,6 +32,7 @@
 #include "clang/Sema/SemaInternal.h"
 #include "clang/Sema/Template.h"
 #include "clang/Sema/TemplateDeduction.h"
+#include "clang/Analysis/AnalysisDeclContext.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/STLExtras.h"
@@ -5458,6 +5459,11 @@ TryObjectArgumentInitialization(Sema &S, SourceLocation Loc, QualType FromType,
   }
 
   QualType ImplicitParamType = S.Context.getQualifiedType(ClassType, Quals);
+
+  if(clang::AnalysisDeclContext::isInClientNamespace(ActingContext))
+  {
+    ImplicitParamType = S.Context.getAddrSpaceQualType(ImplicitParamType, clang::LangAS::cheerp_client);
+  }
 
   // Set up the conversion sequence as a "bad" conversion, to allow us
   // to exit early.

--- a/clang/test/Cheerp/client/catch-client.cpp
+++ b/clang/test/Cheerp/client/catch-client.cpp
@@ -1,6 +1,6 @@
 // RUN: not %clang_cc1 -triple cheerp-leaningtech-webbrowser-genericjs -fexceptions -fcxx-exceptions %s 2>&1 | FileCheck %s
 
-// CHECK: error: Cheerp: Pointer to type 'client::Object' declared in the client namespace cannot be caught directly. Use 'cheerp::JSException' to capture foreign exceptions.
+// CHECK: error: Cheerp: Pointer to type 'client_as client::Object' declared in the client namespace cannot be caught directly. Use 'cheerp::JSException' to capture foreign exceptions.
 
 namespace [[cheerp::genericjs]] client
 {

--- a/clang/test/Cheerp/client/throw-client.cpp
+++ b/clang/test/Cheerp/client/throw-client.cpp
@@ -1,6 +1,6 @@
 // RUN: not %clang_cc1 -triple cheerp-leaningtech-webbrowser-genericjs -fexceptions -fcxx-exceptions %s 2>&1 | FileCheck %s
 
-// CHECK: error: Cheerp: Pointer to type 'client::Object' declared in the client namespace cannot be thrown
+// CHECK: error: Cheerp: Pointer to type 'client_as client::Object' declared in the client namespace cannot be thrown
 
 namespace [[cheerp::genericjs]] client
 {

--- a/clang/test/SemaCXX/address-space-newdelete.cpp
+++ b/clang/test/SemaCXX/address-space-newdelete.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsyntax-only -verify %s
+// RUN: %clang_cc1 -triple %itanium_abi_triple -fsyntax-only -verify %s
 
 void* operator new (__SIZE_TYPE__ size, void* ptr);
 void* operator new[](__SIZE_TYPE__ size, void* ptr);

--- a/clang/test/SemaTemplate/address_space-dependent.cpp
+++ b/clang/test/SemaTemplate/address_space-dependent.cpp
@@ -43,7 +43,7 @@ void neg() {
 
 template <long int I>
 void tooBig() {
-  __attribute__((address_space(I))) int *bounds; // expected-error {{address space is larger than the maximum supported (8388587)}}
+  __attribute__((address_space(I))) int *bounds; // expected-error {{address space is larger than the maximum supported (8388586)}}
 }
 
 template <long int I>
@@ -101,7 +101,7 @@ int main() {
   car<1, 2, 3>(); // expected-note {{in instantiation of function template specialization 'car<1, 2, 3>' requested here}}
   HasASTemplateFields<1> HASTF;
   neg<-1>(); // expected-note {{in instantiation of function template specialization 'neg<-1>' requested here}}
-  correct<0x7FFFEB>();
+  correct<0x7FFFEA>();
   tooBig<8388650>(); // expected-note {{in instantiation of function template specialization 'tooBig<8388650L>' requested here}}
 
   __attribute__((address_space(1))) char *x;

--- a/llvm/include/llvm/Cheerp/Utility.h
+++ b/llvm/include/llvm/Cheerp/Utility.h
@@ -250,6 +250,8 @@ inline bool isBitCast(const llvm::Value* v)
 {
 	if( llvm::isa< llvm::BitCastInst>(v) )
 		return true;
+	if( llvm::isa< llvm::AddrSpaceCastInst>(v) )
+		return true;
 	if(const llvm::ConstantExpr * ce = llvm::dyn_cast<llvm::ConstantExpr>(v) )
 		return ce->getOpcode() == llvm::Instruction::BitCast;
 	if(const llvm::IntrinsicInst* II=llvm::dyn_cast<llvm::IntrinsicInst>(v))

--- a/llvm/include/llvm/Cheerp/Utility.h
+++ b/llvm/include/llvm/Cheerp/Utility.h
@@ -395,7 +395,10 @@ public:
 
 	static bool isClientPtrType(llvm::PointerType* ptr)
 	{
-		return isClientType(ptr->getPointerElementType());
+		bool ret = ptr->getAddressSpace() == 1;
+			// Sanity check. remove when we drop non-opaque pointer types
+		assert(ret == isClientType(ptr->getPointerElementType()));
+		return ret;
 	}
 
 	static bool isWasiFuncName(llvm::StringRef ident)

--- a/llvm/include/llvm/IR/Attributes.td
+++ b/llvm/include/llvm/IR/Attributes.td
@@ -97,7 +97,7 @@ def DereferenceableOrNull : IntAttr<"dereferenceable_or_null",
 def DisableSanitizerInstrumentation: EnumAttr<"disable_sanitizer_instrumentation", [FnAttr]>;
 
 /// Provide pointer element type to intrinsic.
-def ElementType : TypeAttr<"elementtype", [ParamAttr]>;
+def ElementType : TypeAttr<"elementtype", [ParamAttr, RetAttr]>;
 
 /// Whether to keep return instructions, or replace with a jump to an external
 /// symbol.

--- a/llvm/lib/CheerpUtils/GlobalDepsAnalyzer.cpp
+++ b/llvm/lib/CheerpUtils/GlobalDepsAnalyzer.cpp
@@ -1445,6 +1445,7 @@ void GlobalDepsAnalyzer::visitFunction(const Function* F, VisitedSet& visited)
 	if (F->getIntrinsicID() == Intrinsic::cheerp_downcast)
 	{
 		Type* elementType = nullptr;
+		Type* retType = nullptr;
 		for (auto* u : F->users())
 		{
 			if (const CallBase* CB = dyn_cast<CallBase>(u))
@@ -1454,12 +1455,16 @@ void GlobalDepsAnalyzer::visitFunction(const Function* F, VisitedSet& visited)
 					elementType = currElementType;
 				else
 					assert(elementType == currElementType);
+				Type* currRetType = CB->getAttributes().getRetAttrs().getElementType();
+				if (!retType)
+					retType = currRetType;
+				else
+					assert(retType == currRetType);
 			}
 		}
-		if (!elementType)
+		if (!elementType || !retType)
 			return;
 
-		Type* retType = F->getReturnType()->getPointerElementType();
 		// A downcast from a type to i8* is conventially used to support pointers to
 		// member functions and does not imply that the type needs the downcast array
 		Type* ty = retType->isIntegerTy(8) ? elementType : retType;

--- a/llvm/lib/CheerpUtils/TypeOptimizer.cpp
+++ b/llvm/lib/CheerpUtils/TypeOptimizer.cpp
@@ -126,7 +126,7 @@ void TypeOptimizer::gatherAllTypesInfo(const Module& M)
 					if(II->getIntrinsicID()==Intrinsic::cheerp_downcast)
 					{
 						Type* opType = II->getParamElementType(0);
-						Type* retType = II->getType()->getPointerElementType();
+						Type* retType = II->getAttributes().getRetAttrs().getElementType();
 						// In the special case of downcast from i8* to i8* we are dealing with exceptions.
 						// We collect the types info from another syntetic downcast, so just skip here.
 						if(opType->isIntegerTy())

--- a/llvm/lib/CheerpUtils/TypeOptimizer.cpp
+++ b/llvm/lib/CheerpUtils/TypeOptimizer.cpp
@@ -1823,6 +1823,22 @@ void TypeOptimizer::rewriteFunction(Function* F)
 								nextArgNo += 1;
 							}
 						}
+						AttrBuilder retAttributes(CI->getContext());
+						for (auto attr: CallPAL.getRetAttrs())
+						{
+							if (attr.getKindAsEnum() == Attribute::ElementType)
+							{
+								llvm::Type* newType = rewriteType(attr.getValueAsType()).mappedType;
+								if (newType->isArrayTy())
+									newType = newType->getArrayElementType();
+								Attribute newRetAttr = attr.getWithNewType(CI->getContext(), newType);
+								retAttributes.addAttribute(newRetAttr);
+							}
+							else
+							{
+								retAttributes.addAttribute(attr);
+							}
+						}
 
 						SmallVector<OperandBundleDef, 1> OpBundles;
 						CI->getOperandBundlesAsDefs(OpBundles);
@@ -1848,7 +1864,7 @@ void TypeOptimizer::rewriteFunction(Function* F)
 						NewCall->setCallingConv(CI->getCallingConv());
 						NewCall->setAttributes(AttributeList::get(F->getContext(), {
 							AttributeList::get(F->getContext(), CallPAL.getFnAttrs(),
-								CallPAL.getRetAttrs(), {}),
+								AttributeSet::get(F->getContext(), retAttributes), {}),
 							paramAttributes
 							}));
 						NewCall->setDebugLoc(CI->getDebugLoc());

--- a/llvm/lib/CheerpUtils/TypeOptimizer.cpp
+++ b/llvm/lib/CheerpUtils/TypeOptimizer.cpp
@@ -866,6 +866,13 @@ std::pair<Constant*, uint8_t> TypeOptimizer::rewriteConstant(Constant* C, bool r
 				Constant* srcOperand = rewrittenOperand.first;
 				return std::make_pair(ConstantExpr::getBitCast(srcOperand, newTypeInfo.mappedType), 0);
 			}
+			case Instruction::AddrSpaceCast:
+			{
+				auto rewrittenOperand = rewriteConstant(CE->getOperand(0), false);
+				assert(rewrittenOperand.second == 0);
+				Constant* srcOperand = rewrittenOperand.first;
+				return std::make_pair(ConstantExpr::getPointerBitCastOrAddrSpaceCast(srcOperand, newTypeInfo.mappedType), 0);
+			}
 			case Instruction::IntToPtr:
 			{
 				return std::make_pair(ConstantExpr::getIntToPtr(CE->getOperand(0), newTypeInfo.mappedType), 0);
@@ -2034,6 +2041,7 @@ void TypeOptimizer::rewriteFunction(Function* F)
 					break;
 				}
 				case Instruction::BitCast:
+				case Instruction::AddrSpaceCast:
 				case Instruction::ExtractValue:
 				case Instruction::InsertValue:
 				case Instruction::IntToPtr:

--- a/llvm/lib/CheerpUtils/Utility.cpp
+++ b/llvm/lib/CheerpUtils/Utility.cpp
@@ -494,6 +494,7 @@ bool InlineableCache::isInlineableImpl(const Instruction& I)
 			case Instruction::PtrToInt:
 			case Instruction::IntToPtr:
 			case Instruction::ShuffleVector:
+			case Instruction::AddrSpaceCast:
 				return true;
 			case Instruction::ExtractElement:
 			case Instruction::InsertElement:

--- a/llvm/lib/CheerpWriter/CheerpWriter.cpp
+++ b/llvm/lib/CheerpWriter/CheerpWriter.cpp
@@ -2219,6 +2219,11 @@ void CheerpWriter::compileConstantExpr(const ConstantExpr* ce, PARENT_PRIORITY p
 			compileBitCast(ce, k, parentPrio);
 			break;
 		}
+		case Instruction::AddrSpaceCast:
+		{
+			compileOperand(ce->getOperand(0), parentPrio);
+			break;
+		}
 		case Instruction::IntToPtr:
 		{
 			compileOperand(ce->getOperand(0), parentPrio);
@@ -3641,6 +3646,11 @@ CheerpWriter::COMPILE_INSTRUCTION_FEEDBACK CheerpWriter::compileInlineableInstru
 		{
 			POINTER_KIND k=PA.getPointerKindAssert(&I);
 			compileBitCast(&I, k, parentPrio);
+			return COMPILE_OK;
+		}
+		case Instruction::AddrSpaceCast:
+		{
+			compileOperand(I.getOperand(0), parentPrio);
 			return COMPILE_OK;
 		}
 		case Instruction::FPToSI:

--- a/llvm/lib/ExecutionEngine/Interpreter/Execution.cpp
+++ b/llvm/lib/ExecutionEngine/Interpreter/Execution.cpp
@@ -1770,6 +1770,12 @@ GenericValue Interpreter::executeBitCastInst(Value *SrcVal, Type *DstTy,
   return Dest;
 }
 
+GenericValue Interpreter::executeAddrSpaceCastInst(Value *SrcVal, Type *DstTy,
+                                             ExecutionContext &SF) {
+  GenericValue Dest, Src = getOperandValue(SrcVal, SF);
+  return Dest;
+}
+
 void Interpreter::visitTruncInst(TruncInst &I) {
   ExecutionContext &SF = ECStack.back();
   SetValue(&I, executeTruncInst(I.getOperand(0), I.getType(), SF), SF);
@@ -1828,6 +1834,11 @@ void Interpreter::visitIntToPtrInst(IntToPtrInst &I) {
 void Interpreter::visitBitCastInst(BitCastInst &I) {
   ExecutionContext &SF = ECStack.back();
   SetValue(&I, executeBitCastInst(I.getOperand(0), I.getType(), SF), SF);
+}
+
+void Interpreter::visitAddrSpaceCastInst(AddrSpaceCastInst &I) {
+  ExecutionContext &SF = ECStack.back();
+  SetValue(&I, executeAddrSpaceCastInst(I.getOperand(0), I.getType(), SF), SF);
 }
 
 void Interpreter::visitFreezeInst(FreezeInst &I) {
@@ -2146,6 +2157,8 @@ GenericValue Interpreter::getConstantExprValue (ConstantExpr *CE,
       return executeIntToPtrInst(CE->getOperand(0), CE->getType(), SF);
   case Instruction::BitCast:
       return executeBitCastInst(CE->getOperand(0), CE->getType(), SF);
+  case Instruction::AddrSpaceCast:
+      return executeAddrSpaceCastInst(CE->getOperand(0), CE->getType(), SF);
   case Instruction::GetElementPtr:
     return executeGEPOperation(CE->getOperand(0), gep_type_begin(CE),
                                gep_type_end(CE), SF);

--- a/llvm/lib/ExecutionEngine/Interpreter/Interpreter.h
+++ b/llvm/lib/ExecutionEngine/Interpreter/Interpreter.h
@@ -200,6 +200,7 @@ public:
   void visitPtrToIntInst(PtrToIntInst &I);
   void visitIntToPtrInst(IntToPtrInst &I);
   void visitBitCastInst(BitCastInst &I);
+  void visitAddrSpaceCastInst(AddrSpaceCastInst &I);
   void visitFreezeInst(FreezeInst &I);
   void visitSelectInst(SelectInst &I);
 
@@ -299,6 +300,8 @@ private:
   GenericValue executeIntToPtrInst(Value *SrcVal, Type *DstTy,
                                    ExecutionContext &SF);
   GenericValue executeBitCastInst(Value *SrcVal, Type *DstTy,
+                                  ExecutionContext &SF);
+  GenericValue executeAddrSpaceCastInst(Value *SrcVal, Type *DstTy,
                                   ExecutionContext &SF);
   GenericValue executeFreezeInst(Value *SrcVal, ExecutionContext &SF);
   GenericValue executeCastOperation(Instruction::CastOps opcode, Value *SrcVal,

--- a/llvm/lib/Transforms/Coroutines/CoroEarly.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroEarly.cpp
@@ -95,6 +95,7 @@ void Lowerer::lowerCoroPromise(CoroPromiseInst *Intrin) {
     ConstantInt* Adj = ConstantInt::get(Builder.getInt32Ty(), offset);
     CallBase* CB = Builder.CreateCall(intrinsic, {Operand, Adj});
     CB->addParamAttr(0, Attribute::get(Context, Attribute::ElementType, Builder.getInt8Ty()));
+    CB->addRetAttr(Attribute::get(Context, Attribute::ElementType, Builder.getInt8Ty()));
     Replacement = CB;
   }
 

--- a/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroFrame.cpp
@@ -1547,6 +1547,7 @@ static void createFramePtr(coro::Shape &Shape) {
     ConstantInt* Adj = ConstantInt::get(Builder.getInt32Ty(), 0);
     CallBase* DC = Builder.CreateCall(intrinsic, {Shape.FramePtr, Adj});
     DC->addParamAttr(0, Attribute::get(Builder.getContext(), Attribute::ElementType, FrameTy));
+    DC->addRetAttr(Attribute::get(Builder.getContext(), Attribute::ElementType, FrameTy));
     Shape.FramePtr = DC;
 
     // CHEERP: Add bases metadata to the Frame type, and consider the promise


### PR DESCRIPTION
First batch for the address space work.

This introduces an address space for pointers to client types, and uses it to detect those pointers in PA (with an assertion that the answer matches previous behavior).

Hopefully some of this prepares the way for further use of address spaces.

The first two commits are actually independent but related in scope (removal of some uses of pointer types)