### PR TITLE
[ICF] Fix select miscompile

### DIFF
--- a/llvm/lib/CheerpUtils/IdenticalCodeFolding.cpp
+++ b/llvm/lib/CheerpUtils/IdenticalCodeFolding.cpp
@@ -457,8 +457,8 @@ bool IdenticalCodeFolding::equivalentInstruction(const llvm::Instruction* A, con
 		{
 			const SelectInst* siA = cast<SelectInst>(A);
 			const SelectInst* siB = cast<SelectInst>(B);
-			return CacheAndReturn(equivalentOperand(siA->getTrueValue(), siB->getTrueValue()) ||
-				equivalentOperand(siA->getFalseValue(), siB->getFalseValue()) ||
+			return CacheAndReturn(equivalentOperand(siA->getTrueValue(), siB->getTrueValue()) &&
+				equivalentOperand(siA->getFalseValue(), siB->getFalseValue()) &&
 				equivalentOperand(siA->getCondition(), siB->getCondition()));
 		}
 		case Instruction::SIToFP:


### PR DESCRIPTION
This PR fixes that the ICF pass would possibly fold select instructions that are not completely equivalent.

Example of code that would miscompile before, causing one of the two asserts to fail:
```cpp
#include <cassert>

volatile bool test = true;

int Foo() { return test ? 101 : 202; }
int Bar() { return test ? 42 : 11; }

int main() {
  assert(Foo() == 101);
  assert(Bar() == 42);
}
```