### PR TITLE
Move calculation of global chunks to LMH.

### DIFF
--- a/llvm/include/llvm/Cheerp/WasmWriter.h
+++ b/llvm/include/llvm/Cheerp/WasmWriter.h
@@ -422,18 +422,6 @@ private:
 	void flushGeneric(WasmBuffer& code, const llvm::Instruction& I, const InstructionToDependenciesMap& dependencies);
 	void flushMemoryDependencies(WasmBuffer& code, const llvm::Instruction& I);
 	void flushSetLocalDependencies(WasmBuffer& code, const llvm::Instruction& I);
-
-	struct WasmBytesWriter: public LinearMemoryHelper::ByteListener
-	{
-		WasmBuffer& code;
-		const CheerpWasmWriter& writer;
-		WasmBytesWriter(WasmBuffer& code, const CheerpWasmWriter& writer)
-			: code(code), writer(writer)
-		{
-		}
-		void addByte(uint8_t b) override;
-	};
-
 	struct WasmGepWriter: public LinearMemoryHelper::LinearGepListener
 	{
 		CheerpWasmWriter& writer;
@@ -541,7 +529,6 @@ public:
 	void encodeWasmIntrinsic(WasmBuffer& code, const llvm::Function* F);
 	void encodeBranchTable(WasmBuffer& code, std::vector<uint32_t> table, int32_t defaultBlock);
 	void encodeDataSectionChunk(WasmBuffer& data, uint32_t address, llvm::StringRef buf);
-	uint32_t encodeDataSectionChunks(WasmBuffer& data, uint32_t address, llvm::StringRef buf);
 	void compileFloatToText(WasmBuffer& code, const llvm::APFloat& f, uint32_t precision);
 	GLOBAL_CONSTANT_ENCODING shouldEncodeConstantAsGlobal(const llvm::Constant* C, uint32_t useCount, uint32_t getGlobalCost);
 	bool requiresExplicitAssigment(const llvm::Instruction* phi, const llvm::Value* incoming);

--- a/llvm/include/llvm/Cheerp/Writer.h
+++ b/llvm/include/llvm/Cheerp/Writer.h
@@ -589,14 +589,6 @@ private:
 		}
 		void addByte(uint8_t b) override;
 	};
-	struct BinaryBytesWriter: public LinearMemoryHelper::ByteListener
-	{
-		ostream_proxy& stream;
-		BinaryBytesWriter(ostream_proxy& stream):stream(stream)
-		{
-		}
-		void addByte(uint8_t b) override {stream <<(char)b;};
-	};
 
 	struct AsmJSGepWriter: public LinearMemoryHelper::LinearGepListener
 	{

--- a/llvm/lib/Target/CheerpBackend/CheerpBackend.cpp
+++ b/llvm/lib/Target/CheerpBackend/CheerpBackend.cpp
@@ -121,6 +121,8 @@ bool CheerpWritePass::runOnModule(Module& M)
                  // NOTE: this is not actually required by the spec, but for now chrome
                  // doesn't like growing shared memory
                  !WasmSharedMemory;
+  bool hasAsmjsMem = functionAddressMode == cheerp::LinearMemoryHelperInitializer::FunctionAddressMode::AsmJS &&
+                     (!SecondaryOutputFile.empty() || !SecondaryOutputPath.empty());
 
   if (FixWrongFuncCasts)
     MPM.addPass(cheerp::FixFunctionCastsPass());
@@ -158,7 +160,7 @@ bool CheerpWritePass::runOnModule(Module& M)
   // inside not used instructions which are then not rendered.
   MPM.addPass(createModuleToFunctionPassAdaptor(cheerp::PreserveCheerpAnalysisPassWrapper<DCEPass, Function, FunctionAnalysisManager>()));
   MPM.addPass(cheerp::RegisterizePass(!NoJavaScriptMathFround, LinearOutput == Wasm));
-  MPM.addPass(cheerp::LinearMemoryHelperPass(cheerp::LinearMemoryHelperInitializer({functionAddressMode, CheerpHeapSize, CheerpStackSize, growMem})));
+  MPM.addPass(cheerp::LinearMemoryHelperPass(cheerp::LinearMemoryHelperInitializer({functionAddressMode, CheerpHeapSize, CheerpStackSize, growMem, hasAsmjsMem})));
   MPM.addPass(cheerp::ConstantExprLoweringPass());
   MPM.addPass(cheerp::PointerAnalyzerPass());
   MPM.addPass(cheerp::DelayInstsPass());


### PR DESCRIPTION
LinearMemoryHelper will now calculate the population of the global data. The writers will use this data to encode them. This is done so the information for global data is available sooner.