### PR TITLE
Clientlib virtual inheritance

### DIFF
--- a/clang/lib/CodeGen/CGClass.cpp
+++ b/clang/lib/CodeGen/CGClass.cpp
@@ -424,7 +424,9 @@ Address CodeGenFunction::GetAddressOfBaseClass(
   // First handle the non-byte addressable case (Cheerp normal)
   if (!getTarget().isByteAddressable() && !asmjs)
   {
-    if (VBase) {
+    // No cast is needed for virtual classes in the client namespace, all
+    // fields are accessible directly on the derived class.
+    if (VBase && !VBase->isClientNamespace()) {
       Value = GenerateVirtualcast(Value, VBase, VirtualOffset);
       Derived = VBase;
     }

--- a/clang/lib/CodeGen/CGClass.cpp
+++ b/clang/lib/CodeGen/CGClass.cpp
@@ -496,6 +496,13 @@ CodeGenModule::ComputeBaseIdOffset(const CXXRecordDecl *DerivedClass,
 unsigned
 CodeGenModule::ComputeVirtualBaseIdOffset(const CXXRecordDecl *Derived,
                                    const CXXRecordDecl* VBase) {
+  // Empty base classes are handled differently because getVirtualBaseIndex
+  // uses CompleteObjectVirtualBases, which does not store empty base classes.
+  // The actual offset returned here is not very important because an empty
+  // class does not have any members to dereference.
+  if (VBase->isEmpty())
+    return 0;
+
   // Get the layout.
   const CGRecordLayout &Layout = getTypes().getCGRecordLayout(Derived);
   unsigned baseId = Layout.getVirtualBaseIndex(VBase);


### PR DESCRIPTION
This PR fixes two issues related to virtual inheritance.
Previously, these programs did not compile due to failed assertions in cheerp or malformed bitcode being generated.

1. Virtual inheritance with empty base class
```cpp
class [[cheerp::genericjs]] Base {
};

class [[cheerp::genericjs]] Derived : public virtual Base {
};

[[cheerp::genericjs]]
Derived* getInstance() {
        return new Derived;
}
```

2. Virtual inheritance in client namespace
```cpp
namespace [[cheerp::genericjs]] client {
        class [[cheerp::client_layout]] Base {
        public:
                Base();
                void test();
        };

        class Derived : public virtual Base {
        public:
                Derived();
        };
}

[[cheerp::genericjs]]
int main() {
        (new client::Derived)->test();
}
```

See comments in the source code for an explanation of the changes.