### PR TITLE
ci: use ccache for building cheerp-compiler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,9 +27,18 @@ jobs:
     environment:
       - NINJA_STATUS: "[%u/%r/%f] "
       - THREADS: "6"
+      - CCACHE_DIR: "/ccache"
     steps:
       - attach_workspace:
           at: ~/project/packages
+      - run:
+          name: Setup ccache
+          command: |
+            mkdir /ccache
+      - restore_cache:
+          name: Restore ccache
+          keys:
+            - cheerp-compiler
       - run:
           name: Clone Cheerp
           command: |
@@ -48,6 +57,11 @@ jobs:
       - build-internal:
           directory: cheerp-compiler
           package-name: llvm-clang
+      - save_cache:
+          name: Save ccache
+          key: cheerp-compiler
+          paths:
+            - /ccache
       - run:
           name: Save build
           working_directory: ~/project/cheerp-compiler
@@ -63,6 +77,7 @@ jobs:
     resource_class: large
     environment:
       - NINJA_STATUS: "[%u/%r/%f] "
+      - CCACHE_DISABLE: 1
     steps:
       - attach_workspace:
           at: ~/project/packages

--- a/debian/rules
+++ b/debian/rules
@@ -3,7 +3,13 @@
 deb_version := $(shell dpkg-parsechangelog | sed -n 's/^Version: //p')
 ifndef CIRCLECI
 	FLAGS_RELEASE="-DNDEBUG -O2"
+	USE_CCACHE=Off
 else
+	ifeq (${CIRCLE_BRANCH}, master)
+		USE_CCACHE=Off
+	else
+		USE_CCACHE=On
+	endif
 	FLAGS_RELEASE="-O2"
 endif
 
@@ -25,6 +31,7 @@ override_dh_auto_configure:
 		-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld \
 		-DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=lld \
 		-DCMAKE_MODULE_LINKER_FLAGS=-fuse-ld=lld \
+		-DLLVM_CCACHE_BUILD=${USE_CCACHE}
 
 override_dh_auto_install:
 	cd build && DESTDIR=${PWD}/debian/tmp ninja install-distribution


### PR DESCRIPTION
I've disabled the caching for the master branch.