### PR TITLE
[ICF] Compare alloca position for testing equivalence

### DIFF
--- a/llvm/include/llvm/Cheerp/IdenticalCodeFolding.h
+++ b/llvm/include/llvm/Cheerp/IdenticalCodeFolding.h
@@ -68,6 +68,7 @@ private:
 	std::unordered_map<std::pair<const llvm::Function*, const llvm::Function*>, bool, pair_hash> functionEquivalence;
 	std::unordered_map<const llvm::Function*, bool> externalFunctionMapping;
 	std::vector<llvm::Function*> deleteList;
+	std::unordered_map<const llvm::AllocaInst*, const llvm::AllocaInst*> allocaPairs;
 };
 
 class HashAccumulator64 {


### PR DESCRIPTION
This fixes an incorrect detection of identical code involving alloca ordering.

Previously for allocas, we only checked if the allocated type, operands and alignment were the same. However this doesn't take into account that two identical alloca instructions at different relative points in the function can not be taken for the same.

Fixed by adding a map that keeps track of allocas that take place at relatively the same position, and using that map to check alloca equivalence.

An example of miscompiled code (compiled with `-O0`):
```cpp
#include <cassert>

void Fill(int& a, int& b) {
	a = 1;
	b = 2;
}

int Foo() {
	int a = 0;
	int b = 0;
	Fill(a, b);
	return a;
}

int Bar() {
	int a = 0;
	int b = 0;
	Fill(a, b);
	return b;
}

int main() {
	assert(Foo() == 1);
	assert(Bar() == 2);
}
```

This would generate the following IR before ICF for the functions Foo and Bar:
```llvm
; Function Attrs: mustprogress nofree noinline norecurse nosync nounwind willreturn memory(none)
define internal fastcc noundef i32 @_Z3Foov() unnamed_addr #1 section "asmjs" {
entry:
  %a = alloca i32, align 4
  %b = alloca i32, align 4
  store i32 0, i32* %a, align 4
  call fastcc void @_Z4FillRiS_(i32* noundef nonnull align 4 dereferenceable(4) %a, i32* noundef nonnull align 4 dereferenceable(4) %b)
  %0 = load i32, i32* %a, align 4
  ret i32 %0
}

; Function Attrs: mustprogress nofree noinline norecurse nosync nounwind willreturn memory(none)
define internal fastcc noundef i32 @_Z3Barv() unnamed_addr #1 section "asmjs" {
entry:
  %a = alloca i32, align 4
  %b = alloca i32, align 4
  store i32 0, i32* %b, align 4
  call fastcc void @_Z4FillRiS_(i32* noundef nonnull align 4 dereferenceable(4) %a, i32* noundef nonnull align 4 dereferenceable(4) %b)
  %0 = load i32, i32* %b, align 4
  ret i32 %0
}
```

The instructions:
```llvm
  %0 = load i32, i32* %a, align 4
```
```llvm
  %0 = load i32, i32* %b, align 4
```
Would be taken for the same, resulting in a miscompile.