### PR TITLE
Make some string functions able to be weak aliases

### DIFF
--- a/llvm/lib/CheerpUtils/GlobalDepsAnalyzer.cpp
+++ b/llvm/lib/CheerpUtils/GlobalDepsAnalyzer.cpp
@@ -150,6 +150,9 @@ bool GlobalDepsAnalyzer::runOnModule( llvm::Module & module )
 	replaceFunctionAliasWithAliasee(module, "calloc");
 	replaceFunctionAliasWithAliasee(module, "realloc");
 	replaceFunctionAliasWithAliasee(module, "free");
+	replaceFunctionAliasWithAliasee(module, "memcpy");
+	replaceFunctionAliasWithAliasee(module, "memset");
+	replaceFunctionAliasWithAliasee(module, "memmove");
 
 	// Replace the aliases with the actual values
 	for (auto& a: make_early_inc_range(module.aliases()))


### PR DESCRIPTION
This change is needed for effectively implementing asan, so that it will be able to detect bugs that might happen when using these functions.

This change should work on its own, but you'll only be able to actually make use of it when https://github.com/leaningtech/cheerp-musl/pull/17 is merged.