### PR TITLE
Add option to preserve calls to free in asmjs/wasm

### DIFF
--- a/clang/lib/Driver/ToolChains/WebAssembly.cpp
+++ b/clang/lib/Driver/ToolChains/WebAssembly.cpp
@@ -641,6 +641,12 @@ void cheerp::CheerpOptimizer::ConstructJob(Compilation &C, const JobAction &JA,
     cheerpUseBigInts->render(Args, CmdArgs);
   else if (getToolChain().getTriple().getOS() == llvm::Triple::WASI)
     CmdArgs.push_back("-cheerp-use-bigints");
+
+  // Malloc/Free are probably intercepted when using sanitizers, don't optimize
+  // them out
+  if(Args.hasArg(options::OPT_fsanitize_EQ))
+    CmdArgs.push_back("-cheerp-preserve-free");
+
   if(Arg* cheerpStrictLinkingEq = Args.getLastArg(options::OPT_cheerp_strict_linking_EQ)) {
     if (cheerpStrictLinkingEq->getValue() != StringRef("warning") &&
         cheerpStrictLinkingEq->getValue() != StringRef("error")) {
@@ -649,7 +655,6 @@ void cheerp::CheerpOptimizer::ConstructJob(Compilation &C, const JobAction &JA,
     }
     cheerpStrictLinkingEq->render(Args, CmdArgs);
   }
-
 
   if(Arg* cheerpLinearOutput = Args.getLastArg(options::OPT_cheerp_linear_output_EQ))
     cheerpLinearOutput->render(Args, CmdArgs);
@@ -822,6 +827,10 @@ void cheerp::CheerpCompiler::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back(Args.MakeArgString(linearOut));
   }
 
+  // Malloc/Free are probably intercepted when using sanitizers, don't optimize
+  // them out
+  if(Args.hasArg(options::OPT_fsanitize_EQ))
+    CmdArgs.push_back("-cheerp-preserve-free");
 
   if(Arg* cheerpSecondaryOutputFile = Args.getLastArg(options::OPT_cheerp_secondary_output_file_EQ))
     cheerpSecondaryOutputFile->render(Args, CmdArgs);

--- a/llvm/include/llvm/Cheerp/CommandLine.h
+++ b/llvm/include/llvm/Cheerp/CommandLine.h
@@ -58,5 +58,6 @@ extern llvm::cl::opt<bool> WasmNoGlobalization;
 extern llvm::cl::opt<bool> WasmNoUnalignedMem;
 extern llvm::cl::opt<bool> UseBigInts;
 extern llvm::cl::opt<bool> KeepInvokes;
+extern llvm::cl::opt<bool> PreserveFree;
 
 #endif //_CHEERP_COMMAND_LINE_H

--- a/llvm/include/llvm/Cheerp/GlobalDepsAnalyzer.h
+++ b/llvm/include/llvm/Cheerp/GlobalDepsAnalyzer.h
@@ -277,6 +277,7 @@ private:
 
 	bool llcPass;
 	bool hasUndefinedSymbolErrors;
+	bool preserveFree;
 public:
 	bool forceTypedArrays;
 	bool needsBuiltin(BuiltinInstr::BUILTIN b)

--- a/llvm/lib/CheerpUtils/CommandLine.cpp
+++ b/llvm/lib/CheerpUtils/CommandLine.cpp
@@ -87,3 +87,5 @@ llvm::cl::opt<bool> WasmNoUnalignedMem("cheerp-wasm-no-unaligned-mem", llvm::cl:
 llvm::cl::opt<bool> UseBigInts("cheerp-use-bigints", llvm::cl::desc("Use the BigInt type in JS to represent i64 values"));
 
 llvm::cl::opt<bool> KeepInvokes("cheerp-keep-invokes", llvm::cl::desc("Don't lower invokes to calls"));
+
+llvm::cl::opt<bool> PreserveFree("cheerp-preserve-free", llvm::cl::desc("Don't optimize out calls to free"));

--- a/llvm/lib/CheerpUtils/GlobalDepsAnalyzer.cpp
+++ b/llvm/lib/CheerpUtils/GlobalDepsAnalyzer.cpp
@@ -45,7 +45,7 @@ GlobalDepsAnalyzer::GlobalDepsAnalyzer(MATH_MODE mathMode_, bool llcPass)
 	  entryPoint(NULL), hasCreateClosureUsers(false), hasVAArgs(false),
 	  hasPointerArrays(false), hasAsmJSCode(false), hasAsmJSMemory(false), hasAsmJSMalloc(false),
 	  hasCheerpException(false), mayNeedAsmJSFree(false), llcPass(llcPass),
-	  hasUndefinedSymbolErrors(false), forceTypedArrays(false)
+	  hasUndefinedSymbolErrors(false), forceTypedArrays(false), preserveFree(PreserveFree)
 {
 }
 static void createNullptrFunction(llvm::Module& module)
@@ -694,7 +694,7 @@ bool GlobalDepsAnalyzer::runOnModule( llvm::Module & module )
 		Function* ffree = module.getFunction("free");
 		if (ffree)
 		{
-			if(!hasAsmJSMalloc)
+			if(!hasAsmJSMalloc && !preserveFree)
 			{
 				// The symbol is still used around, so keep it but make it empty
 				ffree->deleteBody();


### PR DESCRIPTION
The GDA detects if there are any calls to malloc, and if not, it will remove any calls to free. This, however, doesn't work with AddressSanitizer, which has defined its own malloc (which is not named "malloc"). When compiled with Asan, the GDA would think that there are no calls to malloc, when this is not actually the case.

This change adds an option that disables this free removal, which is automatically enabled when compiling with sanitizers.