### PR TITLE
Add option to change stack top offset

### DIFF
--- a/llvm/include/llvm/Cheerp/CommandLine.h
+++ b/llvm/include/llvm/Cheerp/CommandLine.h
@@ -40,6 +40,7 @@ extern llvm::cl::list<std::string> ReservedNames;
 extern llvm::cl::opt<std::string> GlobalPrefix;
 extern llvm::cl::opt<unsigned> CheerpHeapSize;
 extern llvm::cl::opt<unsigned> CheerpStackSize;
+extern llvm::cl::opt<unsigned> CheerpStackOffset;
 extern llvm::cl::opt<bool> CheerpNoICF;
 extern llvm::cl::opt<bool> BoundsCheck;
 extern llvm::cl::opt<bool> AvoidWasmTraps;

--- a/llvm/include/llvm/Cheerp/LinearMemoryHelper.h
+++ b/llvm/include/llvm/Cheerp/LinearMemoryHelper.h
@@ -34,6 +34,7 @@ struct LinearMemoryHelperInitializer
 	FunctionAddressMode mode;
 	uint32_t memorySize;
 	uint32_t stackSize;
+	uint32_t stackOffset;
 	bool growMem;
 	bool hasAsmjsMem;
 };
@@ -188,7 +189,7 @@ public:
 		mode(data.mode), functionTables(3, FunctionSignatureHash(/*isStrict*/false), FunctionSignatureCmp(/*isStrict*/false)),
 		functionTypeIndices(3, FunctionSignatureHash(/*isStrict*/false), FunctionSignatureCmp(/*isStrict*/false)),
 		maxFunctionId(0), memorySize(data.memorySize*1024*1024),
-		stackSize(data.stackSize*1024*1024), growMem(data.growMem),
+		stackSize(data.stackSize*1024*1024), stackOffset((data.stackOffset+7) & ~7), growMem(data.growMem),
 		hasAsmjsMem(data.hasAsmjsMem)
 	{
 	}
@@ -430,6 +431,9 @@ private:
 	uint32_t stackSize;
 	// Stack start (it grows downwards)
 	uint32_t stackStart;
+	// Offset from 0x0 to the stack top. Primarily used with Asan to reserve
+	// the lower addresses for null pointer checks
+	uint32_t stackOffset;
 	// Whether memory can grow at runtime or not
 	bool growMem;
 	// Whether there is an extra asmjs memory file.

--- a/llvm/lib/CheerpUtils/CommandLine.cpp
+++ b/llvm/lib/CheerpUtils/CommandLine.cpp
@@ -52,6 +52,8 @@ llvm::cl::opt<unsigned> CheerpHeapSize("cheerp-linear-heap-size", llvm::cl::init
 
 llvm::cl::opt<unsigned> CheerpStackSize("cheerp-linear-stack-size", llvm::cl::init(1), llvm::cl::desc("Desired stack size for the cheerp wasm/asmjs module (in MB)") );
 
+llvm::cl::opt<unsigned> CheerpStackOffset("cheerp-linear-stack-offset", llvm::cl::init(0), llvm::cl::desc("Desired offset from address 0x0 to stack top") );
+
 llvm::cl::opt<bool> CheerpNoICF("cheerp-no-icf", llvm::cl::init(0), llvm::cl::desc("Disable identical code folding for wasm/asmjs") );
 
 llvm::cl::opt<bool> BoundsCheck("cheerp-bounds-check", llvm::cl::desc("Generate debug code for bounds-checking arrays") );

--- a/llvm/lib/CheerpUtils/LinearMemoryHelper.cpp
+++ b/llvm/lib/CheerpUtils/LinearMemoryHelper.cpp
@@ -642,7 +642,7 @@ if (!functionTypeIndices.count(fTy)) { \
 
 void LinearMemoryHelper::addStack()
 {
-	heapStart += stackSize;
+	heapStart += stackSize + stackOffset;
 	stackStart = heapStart - 8;
 }
 

--- a/llvm/lib/Target/CheerpBackend/CheerpBackend.cpp
+++ b/llvm/lib/Target/CheerpBackend/CheerpBackend.cpp
@@ -161,7 +161,7 @@ bool CheerpWritePass::runOnModule(Module& M)
   // inside not used instructions which are then not rendered.
   MPM.addPass(createModuleToFunctionPassAdaptor(cheerp::PreserveCheerpAnalysisPassWrapper<DCEPass, Function, FunctionAnalysisManager>()));
   MPM.addPass(cheerp::RegisterizePass(!NoJavaScriptMathFround, LinearOutput == Wasm));
-  MPM.addPass(cheerp::LinearMemoryHelperPass(cheerp::LinearMemoryHelperInitializer({functionAddressMode, CheerpHeapSize, CheerpStackSize, growMem, hasAsmjsMem})));
+  MPM.addPass(cheerp::LinearMemoryHelperPass(cheerp::LinearMemoryHelperInitializer({functionAddressMode, CheerpHeapSize, CheerpStackSize, CheerpStackOffset, growMem, hasAsmjsMem})));
   if (LinearOutput == LinearOutputTy::Wasm)
     MPM.addPass(cheerp::MemoryInitPass());
   MPM.addPass(cheerp::ConstantExprLoweringPass());


### PR DESCRIPTION
libasan for cheerp will poison the range [0x0, stack_top) to find nullptr derefences. However, by default cheerp will place to stack top at 0x8, which means that it wont detect a bit more complex nullptr derefs, like offsets into structs/classes.

This change adds an option to offset the stack-top by a minimum of n bytes. And by default offsets the stack top by 4MiB when using Asan.