### PR TITLE
ci: actually save cache after build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,8 @@ jobs:
       - restore_cache:
           name: Restore ccache
           keys:
-            - cheerp-compiler
+            - cheerp-compiler-<< pipeline.git.branch >>-
+            - cheerp-compiler-
       - run:
           name: Clone Cheerp
           command: |
@@ -59,7 +60,7 @@ jobs:
           package-name: llvm-clang
       - save_cache:
           name: Save ccache
-          key: cheerp-compiler
+          key: cheerp-compiler-<< pipeline.git.branch >>-{{ epoch }}
           paths:
             - /ccache
       - run:


### PR DESCRIPTION
I thought circleci's caching worked by exact matching the cache key, however, after seeing the ci not updating the cache I learned that the key is prefix matched. Changed so that it appends the time to the cache for unique cache keys.

I've also added the branch name to the cache to avoid cache trashing.