### PR TITLE
ci: speedup ci for feature branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,45 +153,15 @@ jobs:
             - cheerp-libcxx-libcxxabi_*.deb
             - cheerp-libs_*.deb
   test:
+    parameters:
+      target:
+        type: string
     docker:
       - image: leaningtech/cheerp_ci_base:20.04
     resource_class: large
     steps:
-      - attach_workspace:
-          at: packages
-      - run:
-          name: Get tests
-          command: |
-            git clone https://github.com/leaningtech/cheerp-utils.git
-            cd cheerp-utils
-            if [ << pipeline.parameters.release-tag >> != master ]; then
-              git checkout << pipeline.parameters.release-tag >>
-            else
-              git checkout << pipeline.parameters.cheerp-utils-commit >>
-            fi
-      - run: mkdir -p /opt/cheerp
-      - install-deb:
-          package-name: llvm-clang
-      - install-deb:
-          package-name: utils
-      - install-deb:
-          package-name: musl
-      - install-deb:
-          package-name: libcxx-libcxxabi
-      - install-deb:
-          package-name: libs
-      - run:
-          name: test
-          working_directory: ~/project/cheerp-utils/tests
-          command: ./run_tests.py --all --determinism=3 --determinism-probability=0.2 "/opt/cheerp/bin/clang++" "node --experimental-wasm-reftypes" -j4
-          no_output_timeout: 30m
-      - run:
-          name: Store test results
-          command: |
-            mkdir -p ~/project/testResults
-            mv ~/project/cheerp-utils/tests/testReport.test ~/project/testResults
-      - store_artifacts:
-          path: ~/project/testResults
+      - run-cheerp-tests:
+          target: << parameters.target >>
   RPM-cheerp-compiler:
     docker:
       - image: leaningtech/cheerp_rpm_base:8
@@ -967,6 +937,46 @@ commands:
           package-name: << parameters.package-name >>
       - install-deb:
           package-name: << parameters.package-name >>
+  run-cheerp-tests:
+    parameters:
+      target:
+        type: string
+    steps:
+      - attach_workspace:
+          at: packages
+      - run:
+          name: Get tests
+          command: |
+            git clone https://github.com/leaningtech/cheerp-utils.git
+            cd cheerp-utils
+            if [ << pipeline.parameters.release-tag >> != master ]; then
+              git checkout << pipeline.parameters.release-tag >>
+            else
+              git checkout << pipeline.parameters.cheerp-utils-commit >>
+            fi
+      - run: mkdir -p /opt/cheerp
+      - install-deb:
+          package-name: llvm-clang
+      - install-deb:
+          package-name: utils
+      - install-deb:
+          package-name: musl
+      - install-deb:
+          package-name: libcxx-libcxxabi
+      - install-deb:
+          package-name: libs
+      - run:
+          name: test
+          working_directory: ~/project/cheerp-utils/tests
+          command: ./run_tests.py --<< parameters.target >> --determinism=3 --determinism-probability=0.2 "/opt/cheerp/bin/clang++" "node --experimental-wasm-reftypes" -j4
+          no_output_timeout: 30m
+      - run:
+          name: Store test results
+          command: |
+            mkdir -p ~/project/testResults
+            mv ~/project/cheerp-utils/tests/testReport.test ~/project/<< parameters.target >>testResults
+      - store_artifacts:
+          path: ~/project/<< parameters.target >>testResults
   build-internal:
     parameters:
       directory:
@@ -1178,6 +1188,9 @@ workflows:
             - define-version-no
             - build-cheerp-compiler
       - test:
+          matrix:
+            parameters:
+              target: ["genericjs", "asmjs", "wasm", "preexecute", "preexecute-asmjs"]
           requires:
             - build-cheerp-compiler
             - build-libraries

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1233,6 +1233,9 @@ workflows:
       - build-cheerp-headers-and-libs:
           requires:
             - build-libraries
+          filters:
+            branches:
+              only: master
       - build-macos:
           requires:
             - build-cheerp-headers-and-libs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,8 @@ jobs:
       - restore_cache:
           name: Restore ccache
           keys:
-            - cheerp-compiler
+            - cheerp-compiler-<< pipeline.git.branch >>-
+            - cheerp-compiler-
       - run:
           name: Clone Cheerp
           command: |
@@ -59,7 +60,7 @@ jobs:
           package-name: llvm-clang
       - save_cache:
           name: Save ccache
-          key: cheerp-compiler
+          key: cheerp-compiler-<< pipeline.git.branch >>-{{ epoch }}
           paths:
             - /ccache
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,9 @@ jobs:
             - cheerp-llvm-clang_*.deb
             - cheerp-build.tar.bz2
   llvm-check:
+    parameters:
+      rule:
+        type: string
     docker:
       - image: leaningtech/cheerp_ci_base:20.04
     resource_class: large
@@ -80,19 +83,8 @@ jobs:
       - NINJA_STATUS: "[%u/%r/%f] "
       - CCACHE_DISABLE: 1
     steps:
-      - attach_workspace:
-          at: ~/project/packages
-      - run: mkdir ~/project/cheerp-compiler
-      - run:
-          name: Extract archive
-          working_directory: ~/project/cheerp-compiler
-          command: |
-            mv ~/project/packages/cheerp-build.tar.bz2 .
-            tar -xf cheerp-build.tar.bz2
-      - run:
-          name: Run llvm check
-          working_directory: ~/project/cheerp-compiler/build
-          command: ninja -j6 check
+      - run-llvm-tests:
+          rule: << parameters.rule >>
   build-libraries:
     docker:
       - image: leaningtech/cheerp_ci_base:20.04
@@ -937,6 +929,28 @@ commands:
           package-name: << parameters.package-name >>
       - install-deb:
           package-name: << parameters.package-name >>
+  run-llvm-tests:
+    parameters:
+      rule:
+        type: string
+    steps:
+      - attach_workspace:
+          at: ~/project/packages
+      - run:
+          name: Install and setup ccache
+          command: |
+            apt update && apt install -y ccache
+      - run: mkdir ~/project/cheerp-compiler
+      - run:
+          name: Extract archive
+          working_directory: ~/project/cheerp-compiler
+          command: |
+            mv ~/project/packages/cheerp-build.tar.bz2 .
+            tar -xf cheerp-build.tar.bz2
+      - run:
+          name: Run llvm << parameters.rule >>
+          working_directory: ~/project/cheerp-compiler/build
+          command: ninja -j6 << parameters.rule >>
   run-cheerp-tests:
     parameters:
       target:
@@ -1181,6 +1195,9 @@ workflows:
           requires:
             - define-version-no
       - llvm-check:
+          matrix:
+            parameters:
+              rule: ["check-llvm", "check-clang"]
           requires:
             - build-cheerp-compiler
       - build-libraries:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,16 +40,23 @@ jobs:
           keys:
             - cheerp-compiler-<< pipeline.git.branch >>-
             - cheerp-compiler-
-      - run:
-          name: Clone Cheerp
-          command: |
-            git clone https://github.com/leaningtech/cheerp-compiler.git
-            cd cheerp-compiler
-            if [ << pipeline.parameters.release-tag >> != 'master' ]; then
-              git checkout << pipeline.parameters.release-tag >>
-            else
-              git checkout << pipeline.parameters.cheerp-compiler-commit >>
-            fi
+      - when:
+          condition:
+            equal: [ master, << pipeline.parameters.release-tag >>  ]
+          steps:
+            shallow-clone:
+              ref: << pipeline.parameters.cheerp-compiler-commit >>
+              dir: cheerp-compiler
+              remote: https://github.com/leaningtech/cheerp-compiler
+      - when:
+          condition:
+            not:
+              equal: [ master, << pipeline.parameters.release-tag >>  ]
+          steps:
+            shallow-clone:
+              ref: << pipeline.parameters.release-tag >>
+              dir: cheerp-compiler
+              remote: https://github.com/leaningtech/cheerp-compiler
       - run:
           name: Set up environment
           working_directory: ~/project/cheerp-compiler
@@ -94,24 +101,47 @@ jobs:
     steps:
       - attach_workspace:
           at: packages
-      - run:
-          name: Get repos
-          command: |
-            git clone https://github.com/leaningtech/cheerp-compiler.git
-            git clone https://github.com/leaningtech/cheerp-utils.git
-            git clone https://github.com/leaningtech/cheerp-libs.git
-            git clone https://github.com/leaningtech/cheerp-musl.git
-            if [ << pipeline.parameters.release-tag >> != master ]; then
-              cd cheerp-compiler && git checkout << pipeline.parameters.release-tag >> && cd ..
-              cd cheerp-utils && git checkout << pipeline.parameters.release-tag >> && cd ..
-              cd cheerp-libs && git checkout << pipeline.parameters.release-tag >> && cd ..
-              cd cheerp-musl && git checkout << pipeline.parameters.release-tag >>
-            else
-              cd cheerp-compiler && git checkout << pipeline.parameters.cheerp-compiler-commit >> && cd ..
-              cd cheerp-utils && git checkout << pipeline.parameters.cheerp-utils-commit >> && cd ..
-              cd cheerp-libs && git checkout << pipeline.parameters.cheerp-libs-commit >> && cd ..
-              cd cheerp-musl && git checkout << pipeline.parameters.cheerp-musl-commit >>
-            fi
+      - when:
+          condition:
+            equal: [ master, << pipeline.parameters.release-tag >>  ]
+          steps:
+            - shallow-clone:
+                ref: << pipeline.parameters.cheerp-compiler-commit >>
+                dir: cheerp-compiler
+                remote: https://github.com/leaningtech/cheerp-compiler
+            - shallow-clone:
+                ref: << pipeline.parameters.cheerp-utils-commit >>
+                dir: cheerp-utils
+                remote: https://github.com/leaningtech/cheerp-utils
+            - shallow-clone:
+                ref: << pipeline.parameters.cheerp-musl-commit >>
+                dir: cheerp-musl
+                remote: https://github.com/leaningtech/cheerp-musl
+            - shallow-clone:
+                ref: << pipeline.parameters.cheerp-libs-commit >>
+                dir: cheerp-libs
+                remote: https://github.com/leaningtech/cheerp-libs
+      - when:
+          condition:
+            not:
+              equal: [ master, << pipeline.parameters.release-tag >>  ]
+          steps:
+            - shallow-clone:
+                ref: << pipeline.parameters.release-tag >>
+                dir: cheerp-compiler
+                remote: https://github.com/leaningtech/cheerp-compiler
+            - shallow-clone:
+                ref: << pipeline.parameters.release-tag >>
+                dir: cheerp-utils
+                remote: https://github.com/leaningtech/cheerp-utils
+            - shallow-clone:
+                ref: << pipeline.parameters.release-tag >>
+                dir: cheerp-musl
+                remote: https://github.com/leaningtech/cheerp-musl
+            - shallow-clone:
+                ref: << pipeline.parameters.release-tag >>
+                dir: cheerp-libs
+                remote: https://github.com/leaningtech/cheerp-libs
       - run:
           name: Set up workspace
           command: |
@@ -917,6 +947,35 @@ jobs:
           path: ~/project/packages
 
 commands:
+  shallow-clone:
+    parameters:
+      ref:
+        type: string
+      dir:
+        type: string
+      remote:
+        type: string
+    steps:
+      - run:
+          name: Get git version info
+          command: git --version
+      - run:
+          name: Create repository directory
+          command: mkdir -p << parameters.dir >>
+      - run:
+          working_directory: << parameters.dir >>
+          name: Initialize repository
+          command: |
+            git init
+            git remote add origin << parameters.remote >>
+      - run:
+          working_directory: << parameters.dir >>
+          name: Fetch repository
+          command: git fetch --progress --depth=1 origin  << parameters.ref >>
+      - run:
+          working_directory: << parameters.dir >>
+          name: Checkout ref
+          command: git checkout --progress --force FETCH_HEAD
   create-deb:
     parameters:
       directory:

--- a/llvm/unittests/Cheerp/CheerpPointerAnalyzerTest.cpp
+++ b/llvm/unittests/Cheerp/CheerpPointerAnalyzerTest.cpp
@@ -37,6 +37,8 @@ TEST(CheerpTest, PointerAnalyzerTest) {
 	SMDiagnostic Err;
 
 	std::unique_ptr<Module> M = parseIRFile( "test/test1.ll", Err, C );
+	if (!M)
+		M = parseIRFile( "test1.ll", Err, C );
 	ASSERT_TRUE( M.get() );
 	
 	const Function * webMain = M->getFunction("_Z7webMainv");


### PR DESCRIPTION
Merge this PR after https://github.com/leaningtech/cheerp-compiler/pull/182

This PR has a few optimizations to the ci on feature branches, speeding it up to about 30 minutes total.

These are mostly low hanging fruit like:
 - Disabling macos/windows builds on feature branches
 - Doing shallow clones for jobs that run on feature branches
 - Running tests in parallel

There's still some other low hanging fruit out there, like:
 - Using zstd instead of bzip2 for compression (a quick local test show that it will probably save up to 2 minutes of the total ci time)
 - Even more parallelization of the tests (primarily the llvm ones)