### PR TITLE
Fix client constructor base initializer arguments

### DIFF
--- a/llvm/lib/CheerpUtils/NativeRewriter.cpp
+++ b/llvm/lib/CheerpUtils/NativeRewriter.cpp
@@ -338,15 +338,14 @@ void CheerpNativeRewriterPass::rewriteConstructorImplementation(Module& M, Funct
 	//Find the right place to add the base construtor call
 	if (lowerConstructor->arg_size()>1)
 		llvm::report_fatal_error("Native constructors with multiple args are not supported", false);
-	Instruction* callPred = NULL;
-	if (lowerConstructor->arg_size()==1 && Instruction::classof(lowerConstructor->getArgOperand(0)))
+	Instruction* callPred = &newFunc->getEntryBlock().front();
+	if (lowerConstructor->arg_size()==1)
 	{
 		//Switch the argument to the one in the new func
 		lowerConstructor->setArgOperand(0, valueMap[lowerConstructor->getArgOperand(0)]);
-		callPred = cast<Instruction>(lowerConstructor->getArgOperand(0));
+		if (Instruction::classof(lowerConstructor->getArgOperand(0)))
+			callPred = cast<Instruction>(lowerConstructor->getArgOperand(0));
 	}
-	else
-		callPred = &newFunc->getEntryBlock().front();
 
 	//And add it
 	lowerConstructor->insertAfter(callPred);


### PR DESCRIPTION
Fix a crash when passing client constructor arguments directly to a base initializer.

```cpp
namespace [[cheerp::genericjs]] client {
        class [[cheerp::client_layout]] Foo {
        public:
                Foo(double x);
        };

        class Bar: public Foo {
        public:
                Bar(double x): Foo(x) {
                }
        };
}

[[cheerp::genericjs]]
int main() {
        new client::Bar(1.0);
}
```

```
Referring to an argument in another function!
  %1 = call %class._ZN6client3FooE* @cheerpCreate_ZN6client3FooC2Ed(double %x)
```

In `CheerpNativeRewriterPass::rewriteConstructorImplementation`, `valueMap` is used to translate arguments from the old function to the new (rewritten) function, but this was only done when the argument is of type `Instruction`. If the argument is not of type `Instruction`, for example, when it is forwarded directly to the base initializer without modification, the old implementation incorrectly did not use `valueMap` to translate the argument.