### PR TITLE
Fix cast of client type to secondary base class

### DIFF
--- a/clang/lib/CodeGen/CGClass.cpp
+++ b/clang/lib/CodeGen/CGClass.cpp
@@ -430,7 +430,7 @@ Address CodeGenFunction::GetAddressOfBaseClass(
       Value = GenerateVirtualcast(Value, VBase, VirtualOffset);
       Derived = VBase;
     }
-    if (NonVirtualOffset.isZero()) {
+    if (NonVirtualOffset.isZero() || Derived->isClientNamespace()) {
       Value = GenerateUpcastCollapsed(Value, BaseValueTy, Value.getType()->getPointerAddressSpace());
     } else {
       Value = GenerateUpcast(Value, Derived, Start, PathEnd);


### PR DESCRIPTION
Fix a bug where casting a client type to one of its base classes incorrectly adds an extra indirection.

```cpp
#include <cheerp/clientlib.h>

[[cheerp::genericjs]]
int main() {
        client::Element* body = client::document.get_body();
        body->set_innerHTML("test");
}
```

Before (bad):
```js
Lcall=document.body;
Lcall.a3.innerHTML=_cheerpCreate_ZN6client6StringC2EPKc();
```

After (good):
```js
Lcall=document.body;
Lcall.innerHTML=_cheerpCreate_ZN6client6StringC2EPKc();
```

I ended up just using the first workaround I came up with. `CodeGenFunction::GetAddressOfBaseClass` calls `CodeGenModule::computeNonVirtualBaseClassOffset` which calls `Layout.getBaseClassOffset` which looks up the offset from a map `BaseOffsets` which is populated from another functoin `ItaniumRecordLayoutBuilder::LayoutBase`, etc... It's difficult to see what effect a change further down the call tree might have on other functions, so I think just this change is good enough for now.