### PR TITLE
Fix jsexported type in client setter not being wrapped

### DIFF
--- a/llvm/lib/CheerpWriter/CheerpWriter.cpp
+++ b/llvm/lib/CheerpWriter/CheerpWriter.cpp
@@ -67,7 +67,17 @@ CheerpWriter::COMPILE_INSTRUCTION_FEEDBACK CheerpWriter::handleBuiltinNamespace(
 	{
 		if (v->getType()->isPointerTy())
 		{
-			compilePointerAs(v, COMPLETE_OBJECT, LOWEST);
+			if (jsExportedTypes.count(v->getType()->getPointerElementType()))
+			{
+				const auto& name = jsExportedTypes.find(v->getType()->getPointerElementType())->getSecond();
+				stream << "Object.create(" << name << ".prototype,{this:{value:";
+				compilePointerAs(v, COMPLETE_OBJECT, LOWEST);
+				stream << "}})";
+			}
+			else
+			{
+				compilePointerAs(v, COMPLETE_OBJECT, LOWEST);
+			}
 		}
 		else
 		{


### PR DESCRIPTION
When a jsexported type "leaves" C++, it is supposed to be wrapped by a call to `Object.create`. This happened correctly for client function calls, but not for client setters, which are handled in a different code path. This PR fixes this so objects are also wrapped when used in client setters.

Example:

```cpp
#include <cheerp/clientlib.h>

class [[cheerp::jsexport]] [[cheerp::genericjs]] JsEvent {
public:
        [[cheerp::jsexport]] double foo() { return 123; }
};

[[cheerp::genericjs]] int main() {
        auto eventInit = new client::CustomEventInit<JsEvent>();
        eventInit->set_detail(new JsEvent());
        client::document.dispatchEvent(new client::CustomEvent<JsEvent>("test", eventInit));
}
```

```html
<script>
        document.addEventListener("test", event => console.log(event.detail.foo()));
</script>
<script src="main.js"></script>
```

Before:

```
Uncaught TypeError: event.detail.foo is not a function
```

After:

```
123
```