### PR TITLE
Fix incorrect pointer kind being used when passing [[cheerp::jsexport]]-ed class to client setter

### DIFF
--- a/llvm/lib/CheerpWriter/CheerpWriter.cpp
+++ b/llvm/lib/CheerpWriter/CheerpWriter.cpp
@@ -71,7 +71,8 @@ CheerpWriter::COMPILE_INSTRUCTION_FEEDBACK CheerpWriter::handleBuiltinNamespace(
 			{
 				const auto& name = jsExportedTypes.find(v->getType()->getPointerElementType())->getSecond();
 				stream << "Object.create(" << name << ".prototype,{this:{value:";
-				compilePointerAs(v, COMPLETE_OBJECT, LOWEST);
+				POINTER_KIND kind = PA.getPointerKindForJSExportedType(v->getType()->getPointerElementType());
+				compilePointerAs(v, kind, LOWEST);
 				stream << "}})";
 			}
 			else


### PR DESCRIPTION
Fix a mistake in https://github.com/leaningtech/cheerp-compiler/pull/188.

The change in that PR wrongfully assumed that `[[cheerp::jsexport]]` classes also always have `[[cheerp::genericjs]]`, instead of checking the pointer kind as it should have done.