### PR TITLE
Allow std::nullptr_t in client functions

### DIFF
--- a/clang/include/clang/Sema/SemaCheerp.h
+++ b/clang/include/clang/Sema/SemaCheerp.h
@@ -24,7 +24,7 @@ namespace cheerp{
 
 enum class TypeKind
 {
-	Void, Boolean, IntLess32Bit, UnsignedInt32Bit, SignedInt32Bit, IntGreater32Bit, FloatingPoint, NamespaceClient, Pointer, Function, FunctionPointer, Reference, JsExportable, Other, Impossible,
+	Void, Boolean, IntLess32Bit, UnsignedInt32Bit, SignedInt32Bit, IntGreater32Bit, FloatingPoint, NamespaceClient, Pointer, Function, FunctionPointer, Reference, JsExportable, Other, Impossible, NullPtr,
 };
 
 enum class SpecialFunctionClassify

--- a/clang/lib/Sema/SemaCheerp.cpp
+++ b/clang/lib/Sema/SemaCheerp.cpp
@@ -196,6 +196,7 @@ void cheerp::TypeChecker::checkTypeImpl(const clang::QualType& Ty, clang::Source
 		case TypeKind::UnsignedInt32Bit:
 		case TypeKind::SignedInt32Bit:
 		case TypeKind::FloatingPoint:
+		case TypeKind::NullPtr:
 		{
 			//Good!
 			return;
@@ -334,6 +335,10 @@ cheerp::TypeKind cheerp::TypeChecker::classifyType(const clang::QualType& Qy, co
 	if (Ty->isPointerType())
 	{
 		return TypeKind::Pointer;
+	}
+	if (Ty->isNullPtrType())
+	{
+		return TypeKind::NullPtr;
 	}
 
 	const clang::CXXRecordDecl* Record = Ty->getAsCXXRecordDecl();


### PR DESCRIPTION
Allowing `std::nullptr_t` in client functions makes overloaded functions nicer to use.

For example, imagine a function `foo` that can take either `client::Node*` or`client::TArray<client::Node*>`, but it should also be able to take a null pointer:

```cpp
namespace [[cheerp::genericjs]] client {
    void foo(client::Node* arg);
    void foo(client::TArray<client::Node*>* arg);
}
```

With the above declaration, the following code would throw an error:

```cpp
client::foo(nullptr); // error: call to 'foo' is ambiguous
```

Adding an extra overload for `std::nullptr_t` fixes this error:

```cpp
namespace [[cheerp::genericjs]] client {
    void foo(std::nullptr_t arg);
}
```