### PR TITLE
CI: Enable LLVM assertions

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -4,11 +4,14 @@ deb_version := $(shell dpkg-parsechangelog | sed -n 's/^Version: //p')
 ifndef CIRCLECI
 	FLAGS_RELEASE="-DNDEBUG -O2"
 	USE_CCACHE=Off
+	ENABLE_LLVM_ASSERTIONS=Off
 else
 	ifeq (${CIRCLE_BRANCH}, master)
 		USE_CCACHE=Off
+		ENABLE_LLVM_ASSERTIONS=Off
 	else
 		USE_CCACHE=On
+		ENABLE_LLVM_ASSERTIONS=On
 	endif
 	FLAGS_RELEASE="-O2"
 endif
@@ -26,6 +29,7 @@ override_dh_auto_configure:
 		-DLLVM_ENABLE_PROJECTS=clang \
 		../llvm/ \
 		-GNinja \
+		-DLLVM_ENABLE_ASSERTIONS=${ENABLE_LLVM_ASSERTIONS} \
 		-DCMAKE_CXX_COMPILER=clang++ \
 		-DCMAKE_C_COMPILER=clang \
 		-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld \

--- a/llvm/lib/CheerpWriter/PartialExecuter.cpp
+++ b/llvm/lib/CheerpWriter/PartialExecuter.cpp
@@ -629,9 +629,10 @@ public:
 		// We need to allocate a virtual frame for the sake of resolving CEs
 		createStartingCallFrame();
 		bool changed = false;
-		for(const auto& it: fullyKnownCEs)
-		{
-			llvm::ConstantExpr* CE = dyn_cast<llvm::ConstantExpr>(it.first);
+		while (!fullyKnownCEs.empty())  {
+			auto it = fullyKnownCEs.begin();
+			llvm::ConstantExpr* CE = dyn_cast<llvm::ConstantExpr>(it->first);
+			fullyKnownCEs.erase(it);
 			if(CE == nullptr)
 			{
 				// CEs might have already collapse due to previous replacements


### PR DESCRIPTION
This PR enables the cmake option `ENABLE_LLVM_ASSERTIONS` for feature branches, as well as fixing an assertion in the partialexecutor.