### PR TITLE
asan: properly run asan test

### DIFF
--- a/compiler-rt/test/asan/TestCases/heap-overflow-large.cpp
+++ b/compiler-rt/test/asan/TestCases/heap-overflow-large.cpp
@@ -1,10 +1,13 @@
 // Regression test for
 // https://code.google.com/p/address-sanitizer/issues/detail?id=183
 
-// RUN: %clangxx_asan -O2 %s -o %t
-// RUN: not %run %t 12 2>&1 | FileCheck %s
-// RUN: not %run %t 100 2>&1 | FileCheck %s
-// RUN: not %run %t 10000 2>&1 | FileCheck %s
+// RUN: %clangxx_asan -DOFFSET=12 -O2 %s -o %t && not %run %t 2>&1 | FileCheck %s
+// RUN: %clangxx_asan -DOFFSET=1000 -O2 %s -o %t && not %run %t 2>&1 | FileCheck %s
+// RUN: %clangxx_asan -DOFFSET=100000 -O2 %s -o %t && not %run %t 2>&1 | FileCheck %s
+
+// RUN: %clangxx_asan -cheerp-linear-output=asmjs -DOFFSET=12 -O2 %s -o %t && not %run %t 2>&1 | FileCheck %s
+// RUN: %clangxx_asan -cheerp-linear-output=asmjs -DOFFSET=1000 -O2 %s -o %t && not %run %t 2>&1 | FileCheck %s
+// RUN: %clangxx_asan -cheerp-linear-output=asmjs -DOFFSET=100000 -O2 %s -o %t && not %run %t 2>&1 | FileCheck %s
 
 #include <stdlib.h>
 #include <string.h>
@@ -14,8 +17,7 @@ int main(int argc, char *argv[]) {
   fprintf(stderr, "main\n");
   int *x = new int[5];
   memset(x, 0, sizeof(x[0]) * 5);
-  int index = atoi(argv[1]);
-  unsigned res = x[index];
+  unsigned res = x[OFFSET];
   // CHECK: main
   // CHECK-NOT: CHECK failed
   delete[] x;


### PR DESCRIPTION
The test was meant to crash by heap-buffer-overflow. However, the test only checked if the program crashed, not what caused it. Because there are no program arguments (yet) it would always crash through nullptr deref, making the test falsely pass.