### PR TITLE
ci: fix timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,6 +282,7 @@ jobs:
               runtimes/ third-party/ debian/
       - run:
           name: Package cheerp toolchain
+          no_output_timeout: 30m
           command: |
             rm -rf cheerp-compiler/
 


### PR DESCRIPTION
Lintian takes ages to do it's checks, which previously stayed below 10 minutes because the packages were split, but now the packages are merges and have the possibility to take more than 10 minutes for lintian to finish.