### PR TITLE
ASan: add function to enable/disable stacktrace collecion on runtime

### DIFF
--- a/compiler-rt/lib/asan/asan_rtl.cpp
+++ b/compiler-rt/lib/asan/asan_rtl.cpp
@@ -402,6 +402,10 @@ static void AsanInitInternal() {
   // initialization steps look at flags().
   InitializeFlags();
 
+#if SANITIZER_CHEERPWASM
+  __sanitizer_cheerp_set_collect_traces(!common_flags()->disable_traces);
+#endif
+
   WaitForDebugger(flags()->sleep_before_init, "before init");
 
   // Stop performing init at this point if we are being loaded via

--- a/compiler-rt/lib/sanitizer_common/sanitizer_cheerpwasm.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_cheerpwasm.cpp
@@ -20,6 +20,18 @@
 __attribute__((cheerp_asmjs)) char *volatile _stackBottom = (char *)0xdeadbeef;
 __attribute__((cheerp_asmjs)) char *volatile _stackTop = (char *)0xdeadbeef;
 
+static __asan::atomic_sint32_t _collect_traces;
+
+extern "C" {
+void  __sanitizer_cheerp_set_collect_traces(int32_t enabled) {
+  atomic_store(&_collect_traces, enabled, __asan::memory_order_release);
+}
+
+int32_t __sanitizer_cheerp_get_collect_traces() {
+  return atomic_load(&_collect_traces, __asan::memory_order_acquire);
+}
+}
+
 namespace __sanitizer {
 
 void ListOfModules::init() {

--- a/compiler-rt/lib/sanitizer_common/sanitizer_cheerpwasm.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_cheerpwasm.h
@@ -5,8 +5,15 @@
 
 #if SANITIZER_CHEERPWASM
 
+#  include <stdint.h>
+
 #  include "sanitizer_internal_defs.h"
 #  include "sanitizer_platform_limits_cheerpwasm.h"
+
+extern "C" {
+void  __sanitizer_cheerp_set_collect_traces(int32_t enabled);
+int32_t __sanitizer_cheerp_get_collect_traces();
+}
 
 namespace __sanitizer {
 void InitEnv();


### PR DESCRIPTION
With this commit, you can call the following c function to either disable or enable stacktrace collection:
`void __sanitizer_cheerp_set_collect_traces(int enabled);`
A value of zero will disable stacktrace collection, anything else will enable it.

This is implemented in a slightly hacky way, but probably will never go wrong, and if for some reason it does go wrong, it will just mean that no stacktrace is printed for a single specific function even though it was enabled.