### PR TITLE
cheerp: make arguments/environment variables array null by default

### DIFF
--- a/llvm/lib/CheerpWriter/CheerpWriter.cpp
+++ b/llvm/lib/CheerpWriter/CheerpWriter.cpp
@@ -1000,7 +1000,7 @@ CheerpWriter::COMPILE_INSTRUCTION_FEEDBACK CheerpWriter::handleBuiltinCall(const
 		if (makeModule == MODULE_TYPE::ES6)
 			stream << EnvironName;
 		else
-			stream  << "typeof " << EnvironName << " == 'undefined' ? [] : " << EnvironName;
+			stream  << "typeof " << EnvironName << " == 'undefined' ? null : " << EnvironName;
 		return COMPILE_OK;
 	}
 	else if(intrinsicId==Intrinsic::cheerp_argv)
@@ -1008,7 +1008,7 @@ CheerpWriter::COMPILE_INSTRUCTION_FEEDBACK CheerpWriter::handleBuiltinCall(const
 		if (makeModule == MODULE_TYPE::ES6)
 			stream << ArgvName;
 		else
-			stream  << "typeof " << ArgvName << " == 'undefined' ? [] : " << ArgvName;
+			stream  << "typeof " << ArgvName << " == 'undefined' ? null : " << ArgvName;
 		return COMPILE_OK;
 	}
 	else if(intrinsicId==Intrinsic::abs)
@@ -6268,8 +6268,8 @@ void CheerpWriter::compileHelpers()
 	}
 
 	if (makeModule == MODULE_TYPE::ES6) {
-		stream << "var " <<  EnvironName << "=[],";
-		stream << ArgvName << "=[];" << NewLine;
+		stream << "var " <<  EnvironName << "=null,";
+		stream << ArgvName << "=null;" << NewLine;
 	}
 }
 
@@ -6593,8 +6593,8 @@ void CheerpWriter::compileDeclareExports()
 	{
 		const std::string shortestName = namegen.getShortestLocalName();
 		stream << "export default function(" << shortestName << "){" << NewLine;
-		stream << EnvironName << "=" << shortestName << "?.env??[];" << NewLine;
-		stream << ArgvName << "=" << shortestName << "?.argv??[];" << NewLine;
+		stream << EnvironName << "=" << shortestName << "?.env??null;" << NewLine;
+		stream << ArgvName << "=" << shortestName << "?.argv??null;" << NewLine;
 		stream << "return ";
 	}
 	else


### PR DESCRIPTION
This is needed to make the distinction between whether nothing was specified or an empty array was specified. Please merge https://github.com/leaningtech/cheerp-libs/pull/22 before this one.