### PR TITLE
structmemfunclowering: fix crash when gep is optimized away

### DIFF
--- a/llvm/lib/CheerpUtils/StructMemFuncLowering.cpp
+++ b/llvm/lib/CheerpUtils/StructMemFuncLowering.cpp
@@ -99,16 +99,15 @@ void StructMemFuncLowering::recursiveCopy(IRBuilder<>* IRB, Value* baseDst, Valu
 	{
 		Value* elementSrc = baseSrc;
 		Value* elementDst = baseDst;
-		Type* loadType = containingType;
-		if(indexes.size() != 1 || !isa<ConstantInt>(indexes[0]) || cast<ConstantInt>(indexes[0])->getZExtValue()!=0)
-		{
-			assert(baseSrc->getType() == containingType->getPointerTo());
-			assert(baseSrc->getType() == baseDst->getType());
-			elementSrc = IRB->CreateGEP(containingType, baseSrc, indexes);
-			elementDst = IRB->CreateGEP(containingType, baseDst, indexes);
-			loadType = cast<GEPOperator>(elementDst)->getResultElementType();
-		}
+
+		assert(baseSrc->getType() == containingType->getPointerTo());
+		assert(baseSrc->getType() == baseDst->getType());
+		elementSrc = IRB->CreateGEP(containingType, baseSrc, indexes);
+		elementDst = IRB->CreateGEP(containingType, baseDst, indexes);
+
+		Type* loadType = GetElementPtrInst::getIndexedType(containingType, indexes);
 		assert(loadType->getPointerTo() == elementSrc->getType());
+
 		Instruction* element = IRB->CreateAlignedLoad(loadType, elementSrc, MaybeAlign(baseAlign));
 		MDNode* newAliasScope = NULL;
 		if(aliasDomain)


### PR DESCRIPTION
LLVM is smart enough to be able to remove a gep if the source and indexes are constants. However, it was assumed that it would always emit a gep instruction, which would cause a crash when trying to cast it.

Upon further inspection, I believe that this casting to a GEPOperator and then getting the result element type is overkill, and we could just simply use the type of the value.

This fixes: https://github.com/leaningtech/cheerp-meta/issues/141