### PR TITLE
cmake/ci: add custom built clangd

### DIFF
--- a/llvm/CheerpCmakeConf.cmake
+++ b/llvm/CheerpCmakeConf.cmake
@@ -17,9 +17,13 @@ set(LLVM_TOOLCHAIN_TOOLS
   llc
   CACHE STRING "")
 
+if("${LLVM_ENABLE_PROJECTS}" MATCHES ".*clang-tools-extra.*")
+  set(CHEERP_CLANGD clangd)
+endif()
+
 set(LLVM_DISTRIBUTION_COMPONENTS
   clang
   clang-resource-headers
+  ${CHEERP_CLANGD}
   ${LLVM_TOOLCHAIN_TOOLS}
   CACHE STRING "")
-


### PR DESCRIPTION
This change will add clangd to our packages.

If you want to build clangd manually, you'll have to add `clang-tools-extra` to `LLVM_ENABLE_PROJECTS`. Also if you want it to get installed with the `install-distribution` rule, you'll have to specify `LLVM_ENABLE_PROJECTS` before specifying the initial cache with `-C` (see `debian/build.sh` for an example).

This closes: https://github.com/leaningtech/cheerp-meta/issues/144