### PR TITLE
Skip client namespace checks for methods with inline body.

### DIFF
--- a/clang/lib/Sema/SemaCheerp.cpp
+++ b/clang/lib/Sema/SemaCheerp.cpp
@@ -75,6 +75,10 @@ bool cheerp::isNamespaceClientDisabledDecl(clang::FunctionDecl* FD, clang::Sema&
       if (!isClient || FD->hasBody())
               return false;
 
+      if (auto* MD = clang::dyn_cast<clang::CXXMethodDecl>(FD))
+        if (MD->hasInlineBody())
+          return false;
+
       bool doesWork = TypeChecker::checkSignature<TypeChecker::NamespaceClient, TypeChecker::ReturnValue>(FD, sema);
 
       return !doesWork;


### PR DESCRIPTION
The client namespace checks are skipped for functions that have bodies, if `FunctionDecl::hasBody()` returns true. For the following function, `FunctionDecl::hasBody()` returns false.

```cpp
		template<class T, class = std::enable_if_t<cheerp::CanCast<_Function<cheerp::FunctionType<T>>, _Function<F>>>>
		_Function(T&& func) : Function(cheerp::Callback(func)) {
		}
```

`hasInlineBody()` does return true, and also skipping the check when `hasInlineBody()` returns true "fixes" the issue and allows the above code to compile.

I don't really understand why `hasBody()` returns false here, or why `hasInlineBody()` does not imply `hasBody()`.