### PR TITLE
ci: actually build clangd by default

### DIFF
--- a/debian/build.sh
+++ b/debian/build.sh
@@ -91,7 +91,7 @@ build_compiler() {
     PROJECTS="$PROJECTS;clang-tools-extra"
   fi
 
-  configure_llvm clang
+  configure_llvm "$PROJECTS"
   export DESTDIR="$BUILD_DIR"
   llvm_ninja_command install-distribution
   unset DESTDIR


### PR DESCRIPTION
Forgot to actually build `clang-tools-extra` by default...