### PR TITLE
codegen: bitcast to expanded struct type when accessing its fields

### DIFF
--- a/clang/lib/CodeGen/CGExprConstant.cpp
+++ b/clang/lib/CodeGen/CGExprConstant.cpp
@@ -2025,6 +2025,8 @@ private:
           int32_t fieldIndex = cgLayout.getLLVMFieldNo(FD);
           if(fieldIndex == -1) {
             // Collapsed struct
+            CElementType = CGM.getTypes().ConvertTypeForMem(CurType);
+            C = llvm::ConstantExpr::getBitCast(C, CElementType->getPointerTo());
             continue;
           }
           Indexes.push_back(llvm::ConstantInt::get(CGM.Int32Ty, fieldIndex));


### PR DESCRIPTION
Cheerp, for structs, expands other structs that are in the first member position. During this expansion, for technical reasons, it explicitly already adds the padding to the expanded struct. So for structs like this:
```c
        struct foo {
                uint16_t a;
                //implicit padding of 2 bytes
                uint32_t b;
        };

        struct bar {
                struct foo f;
        }
```
It will actually become something like this:
```c
        struct foo {
                uint16_t a;
                //implicit padding of 2 bytes
                uint32_t b;
        };

        struct bar {
                uint16_t a;
                uint8_t _padding[2];
                uint32_t b;
        }
```
However, accesses to the base struct's fields were not aware of this extra field being added, and falsely assuming that, for `bar`, `b` would still be in the second position like it is for `foo`.

The linear memory layout of these two types is, however, still exactly the same. The only difference for LLVM is that the implicit padding is already there.

Fixed this by bitcasting to the expanded struct type before trying to access its fields.

Closes: https://github.com/leaningtech/cheerp-meta/issues/118

I've checked for the cheerp target, and it doesn't seem to be adding the padding like we might thought it would.

Please merge https://github.com/leaningtech/cheerp-utils/pull/66 before this PR