### PR TITLE
cheerp::client_transparent attribute

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -2185,6 +2185,11 @@ def ClientLayout : Attr {
   let Documentation = [Undocumented];
 }
 
+def ClientTransparent : Attr {
+  let Spellings = [CXX11<"cheerp", "client_transparent">, GNU<"cheerp_client_transparent">];
+  let Documentation = [Undocumented];
+}
+
 def ObjCBridge : InheritableAttr {
   let Spellings = [Clang<"objc_bridge">];
   let Subjects = SubjectList<[Record, TypedefName], ErrorDiag>;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11763,12 +11763,18 @@ def err_cheerp_invalid_plament_new : Error<
   "Cheerp: Placement new is only valid on memory of the same type. If this is a custom allocator, disable it">;
 def err_cheerp_invalid_static : Error<
   "Cheerp: Only static member might be tagged with the legacy [[cheerp::static]] attribute">;
+def err_cheerp_attribute_not_on_constructor : Error<
+  "Cheerp: This attribute can only be used on constructors">;
 def err_cheerp_attribute_not_on_function : Error<
   "Cheerp: This attribute can only be used on functions">;
 def err_cheerp_attribute_on_virtual_class : Error<
   "Cheerp: A virtual class cannot have the %0 attribute">;
 def err_cheerp_interface_name_non_client : Error<
   "Cheerp: Interface name should only be added to namespace client declarations">;
+def err_cheerp_client_transparent_non_client : Error<
+  "Cheerp: [[cheerp::client_transparent]] should only be added to namespace client declarations">;
+def err_cheerp_client_transparent_bad_parameter_count : Error<
+  "Cheerp: A [[cheerp::client_transparent]] constructor must have exactly one parameter">;
 def err_cheerp_jsexport_TODO : Error<
   "Cheerp: Unknown [[cheerp::jsexport]] related problem">;
 def err_cheerp_jsexport_only_static : Error<

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -2405,7 +2405,7 @@ void CodeGenModule::SetFunctionAttributes(GlobalDecl GD, llvm::Function *F,
   }
 
   const auto *FD = cast<FunctionDecl>(GD.getDecl());
-  if (FD)
+  if (FD) {
     if (const auto *Attr = FD->getAttr<CheerpInterfaceNameAttr>()) {
       llvm::Metadata *AttrMDArgs[] = {
         llvm::MDString::get(getLLVMContext(), Attr->getNameInterface()),
@@ -2413,6 +2413,15 @@ void CodeGenModule::SetFunctionAttributes(GlobalDecl GD, llvm::Function *F,
 
       F->setMetadata("cheerp.interfacename", llvm::MDNode::get(getLLVMContext(), AttrMDArgs));
     }
+
+    if (const auto *Attr = FD->getAttr<ClientTransparentAttr>()) {
+      llvm::Metadata *AttrMDArgs[] = {
+        llvm::MDString::get(getLLVMContext(), "true"),
+      };
+
+      F->setMetadata("cheerp.clienttransparent", llvm::MDNode::get(getLLVMContext(), AttrMDArgs));
+    }
+  }
 
   if (!IsIncompleteFunction)
     SetLLVMFunctionAttributes(GD, getTypes().arrangeGlobalDeclaration(GD), F,

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -8498,6 +8498,10 @@ static void handleClientLayoutAttr(Sema &S, Decl *D, const ParsedAttr &Attr) {
   D->addAttr(::new (S.Context) ClientLayoutAttr(S.Context, Attr));
 }
 
+static void handleClientTransparentAttr(Sema &S, Decl *D, const ParsedAttr &Attr) {
+  D->addAttr(::new (S.Context) ClientTransparentAttr(S.Context, Attr));
+}
+
 //===----------------------------------------------------------------------===//
 // Top Level Sema Entry Points
 //===----------------------------------------------------------------------===//
@@ -9348,6 +9352,9 @@ ProcessDeclAttribute(Sema &S, Scope *scope, Decl *D, const ParsedAttr &AL,
     break;
   case ParsedAttr::AT_ClientLayout:
     handleClientLayoutAttr(S, D, AL);
+    break;
+  case ParsedAttr::AT_ClientTransparent:
+    handleClientTransparentAttr(S, D, AL);
     break;
   }
 }

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -8500,6 +8500,16 @@ static void handleClientLayoutAttr(Sema &S, Decl *D, const ParsedAttr &Attr) {
 
 static void handleClientTransparentAttr(Sema &S, Decl *D, const ParsedAttr &Attr) {
   D->addAttr(::new (S.Context) ClientTransparentAttr(S.Context, Attr));
+  // Can only be used on client conversion constructors
+  if (!D->getDeclContext()->isClientNamespace())
+    S.Diag(Attr.getLoc(), diag::err_cheerp_client_transparent_non_client);
+  if (auto* CD = dyn_cast<CXXConstructorDecl>(D))
+  {
+    if (CD->getNumParams() != 1)
+      S.Diag(Attr.getLoc(), diag::err_cheerp_client_transparent_bad_parameter_count);
+  }
+  else
+    S.Diag(Attr.getLoc(), diag::err_cheerp_attribute_not_on_constructor);
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/CheerpUtils/NativeRewriter.cpp
+++ b/llvm/lib/CheerpUtils/NativeRewriter.cpp
@@ -392,13 +392,6 @@ void CheerpNativeRewriterPass::rewriteConstructorImplementation(Module& M, Funct
 
 bool CheerpNativeRewriterPass::rewriteNativeObjectsConstructors(Module& M, Function& F, DominatorTree& DT)
 {
-	if(isBuiltinConstructor(F.getName().data()) &&
-		F.getReturnType()->isVoidTy())
-	{
-		assert(!F.empty());
-		rewriteConstructorImplementation(M, F, DT);
-		return true;
-	}
 	//Vector of the instructions to be removed in the second pass
 	SmallVector<Instruction*, 4> toRemove;
 
@@ -446,6 +439,15 @@ bool CheerpNativeRewriterPass::rewriteNativeObjectsConstructors(Module& M, Funct
 	//Remove the instructions in backward order to avoid dependency issues
 	for(int i=toRemove.size();i>0;i--)
 		toRemove[i-1]->eraseFromParent();
+
+	if(isBuiltinConstructor(F.getName().data()) &&
+		F.getReturnType()->isVoidTy())
+	{
+		assert(!F.empty());
+		rewriteConstructorImplementation(M, F, DT);
+		return true;
+	}
+
 	return Changed;
 }
 


### PR DESCRIPTION
Implement the `cheerp::client_transparent` attribute.

This attribute is used on converting constructors in the client namespace to indicate that, when the conversion happens, it should return its first argument unchanged instead of actually calling the constructor.

This allows for "fake" types that do not have a constructor in javascript to have a "fake" constructor to convert from another type that is known to be compatible.

For example, the `_Union` type represents a value whose type is unknown but restricted to the set of variants listed in its type arguments. The `_Union` type can be used in function parameters to declare that the function is able to take values of any type that is listed in the union. The variants do not inherit from `_Union` so could not be converted without a converting constructor. But, since the `_Union` type is not a real javascript type, the constructor needs to be "transparent". The constructor is not called and the value argument is returned unchanged.

```cpp
template<class T, class = std::enable_if_t<cheerp::CanCast<T, Variants...>>>
[[cheerp::client_transparent]]
_Union(T value);
```

This PR also contains a fix for a bug that occurred when a converting constructor is called within a base initializer. The native rewriter would return early after rewriting the constructor implementation, and thereby skip rewriting any constructor calls within the implementation.

The bug would cause the following (incorrect) code to be generated:

```js
tmp1=new Foo(null);
new Bar(/* ... */);
return tmp1;
```

When it should instead be:

```js
return new Foo(new Bar(/* ... */));
```