### PR TITLE
scevexpander: get type information from scev operands

### DIFF
--- a/llvm/lib/Transforms/Utils/ScalarEvolutionExpander.cpp
+++ b/llvm/lib/Transforms/Utils/ScalarEvolutionExpander.cpp
@@ -1674,7 +1674,7 @@ Value *SCEVExpander::visitPtrToIntExpr(const SCEVPtrToIntExpr *S) {
 
 Value *SCEVExpander::visitGEPPointer(const SCEVGEPPointer *S) {
   llvm::Value* ptrVal = expand(S->getOperand(0));
-  llvm::Type* ptrType = ptrVal->getType();
+  llvm::Type* ptrType = S->getOperand(0)->getType();
   SmallVector<Value *, 4> GepIndices;
   // The pointer is implicitly dereferenced
   GepIndices.push_back(ConstantInt::get(Type::getInt32Ty(SE.getContext()), 0));
@@ -1692,8 +1692,9 @@ Value *SCEVExpander::visitGEPPointer(const SCEVGEPPointer *S) {
       sTy = directBase;
     }
     gepType = sTy;
-    ptrVal = Builder.CreateBitCast(ptrVal, sTy->getPointerTo());
   }
+  if (ptrVal->getType() != gepType->getPointerTo())
+    ptrVal = Builder.CreateBitCast(ptrVal, gepType->getPointerTo());
   Value *GEP = Builder.CreateGEP(gepType, ptrVal, GepIndices, "safescevgep");
   rememberInstruction(GEP);
   return GEP;


### PR DESCRIPTION
`visitGEPPointer` used to get its type information from the expanded first operand as a Value, however, this proved to be too coarse in some cases.

Fixes: https://github.com/leaningtech/cheerp-meta/issues/121