### PR TITLE
Fix inverted condition in NativeRewriter

### DIFF
--- a/llvm/lib/CheerpUtils/NativeRewriter.cpp
+++ b/llvm/lib/CheerpUtils/NativeRewriter.cpp
@@ -328,7 +328,7 @@ void CheerpNativeRewriterPass::rewriteConstructorImplementation(Module& M, Funct
 			lowerConstructor = CallInst::Create(newFunc, newArgs);
 			break;
 		}
-		if(!oldLowerConstructor)
+		if(oldLowerConstructor)
 			break;
 	}
 


### PR DESCRIPTION
In PR #210, this condition was accidentally inverted. The only change here is to uninvert it again.

I assume this wasn't causing any issues because most functions only have one BasicBlock. I'm not sure the if statement makes any sense to begin with, but it's hard to tell without an example of a function that has multiple BasicBlocks. The surrounding loop does more than just look for a lower constructor, it also calls `PromoteMemToReg` on some alloca instructions, so it seems weird to exit early when the lower constructor was found.

I'm ignoring all of these concerns for now, and only revert condition back to what it was before PR #210, regardless of whether this behaviour was correct or not.