### PR TITLE
Fix crash when checking templated base class for client_layout attribute

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -17545,7 +17545,14 @@ static bool hasClientLayout(CXXRecordDecl* RD)
     return true;
   if (RD->bases_begin() == RD->bases_end())
     return false;
-  return hasClientLayout(RD->bases_begin()->getType()->getAsCXXRecordDecl());
+  QualType type = RD->bases_begin()->getType();
+  if (auto* decl = type->getAsCXXRecordDecl())
+    return hasClientLayout(decl);
+  if (auto* templateType = type->getAs<TemplateSpecializationType>())
+    if (auto* templateDecl = templateType->getTemplateName().getAsTemplateDecl())
+      if (auto* decl = dyn_cast<CXXRecordDecl>(templateDecl->getTemplatedDecl()))
+        return hasClientLayout(decl);
+  return false;
 }
 void Sema::ActOnTagFinishDefinition(Scope *S, Decl *TagD,
                                     SourceRange BraceRange) {


### PR DESCRIPTION
When checking a client namespace class for the client_layout attribute, we assumed that base classes are of type `CXXRecordDecl`. This is not always the case. For example, we would get a crash when the base class is templated:
```cpp
namespace client {
	template<class T>
	class [[cheerp::client_layout]] Base {};
	template<class T>
	class Derived : public Base<T> {};
}
```

The client_layout check is updated to also handle templated base classes, and to return false for other unhandled types. So we get the normal missing client layout diagnostic for unhandled types instead of a segmentation fault.