### PR TITLE
Fix regression to collapsing literal structs

### DIFF
--- a/llvm/lib/CheerpUtils/TypeOptimizer.cpp
+++ b/llvm/lib/CheerpUtils/TypeOptimizer.cpp
@@ -292,7 +292,7 @@ bool TypeOptimizer::canCollapseStruct(llvm::StructType* st, llvm::StructType* ne
 	if (newStruct == nullptr)
 	{
 		assert(st->isLiteral());
-		return false;
+		return true;
 	}
 	// Stop if the element is just a int8, we may be dealing with an empty struct
 	// Empty structs are unsafe as the int8 inside is just a placeholder and will be replaced


### PR DESCRIPTION
A regression to collapsing literal structs was introduced in commit 5745eea55d666b04c90859205ae1dbf05f60bbfe.

Literal structs can always be collapsed into parent structs, since the parent cannot be literal aswell.