### PR TITLE
Fix clangd phantom errors

### DIFF
--- a/clang/lib/Sema/SemaCheerp.cpp
+++ b/clang/lib/Sema/SemaCheerp.cpp
@@ -72,12 +72,13 @@ bool cheerp::isNamespaceClientDisabledDecl(clang::FunctionDecl* FD, clang::Sema&
 {
       const bool isClient = clang::AnalysisDeclContext::isInClientNamespace(FD);
 
-      if (!isClient || FD->hasBody())
-              return false;
+      clang::FunctionDecl* CheckFD = FD->getTemplateInstantiationPattern();
 
-      if (auto* MD = clang::dyn_cast<clang::CXXMethodDecl>(FD))
-        if (MD->hasInlineBody())
-          return false;
+      if (!CheckFD)
+              CheckFD = FD;
+
+      if (!isClient || CheckFD->isDefined())
+              return false;
 
       bool doesWork = TypeChecker::checkSignature<TypeChecker::NamespaceClient, TypeChecker::ReturnValue>(FD, sema);
 


### PR DESCRIPTION
The most common example of this is probably constructing a `client::String` from a `const char*`.

```cpp
new client::String("Hello, World!");
```

Client functions normally can't take pointers to primitive types, so this call *would* be invalid, if not for the fact that the constructor has a body and is thus is not really a client function.

The client namespace checks are normally skipped for functions that have a body. But clangd seems to discard the body before these checks are run, and erroneously emits an error in this case.

The fix is to replace `hasBody` with `isDefined`, which seems to have mostly the same effect, except that it also works with clangd.