### PR TITLE
Fix throwing transparent constructors

### DIFF
--- a/llvm/lib/CheerpUtils/NativeRewriter.cpp
+++ b/llvm/lib/CheerpUtils/NativeRewriter.cpp
@@ -193,6 +193,8 @@ bool CheerpNativeRewriterPass::rewriteIfNativeConstructorCall(Module& M, Instruc
 	{
 		auto* castInst = new BitCastInst(newI, PointerType::getUnqual(initialArgs[0]->getType()), "", callInst);
 		new StoreInst(initialArgs[0], castInst, callInst);
+		if (auto* inv = dyn_cast<InvokeInst>(callInst))
+			BranchInst::Create(inv->getNormalDest(), inv->getParent());
 		return true;
 	}
 
@@ -201,6 +203,8 @@ bool CheerpNativeRewriterPass::rewriteIfNativeConstructorCall(Module& M, Instruc
 	if (redundantStringConstructor(callInst, initialArgs))
 	{
 		new StoreInst(initialArgs[0], newI, callInst);
+		if (auto* inv = dyn_cast<InvokeInst>(callInst))
+			BranchInst::Create(inv->getNormalDest(), inv->getParent());
 		return true;
 	}
 	Function* newFunc = getReturningConstructor(M, called);


### PR DESCRIPTION
Compiling a program that contains a call to a throwing transparent client constructor (such as `String(const String*)`, or any `[[cheerp::client_transparent]]` constructor) with `-fexceptions` would result in a crash. The crash happens because the invoke instruction that would call the constructor was completely removed, leaving the block without a terminator. This is fixed by inserting a branch instruction at the end of the block.

Example of a program that would trigger the crash:

```cpp
namespace [[cheerp::genericjs]] client {
    class [[cheerp::client_layout]] String {
    public:
        String(const String* other);
    };
}

[[cheerp::genericjs]]
int main() {
    new client::String(nullptr);
}
```