### PR TITLE
Fix several wasm externref issues

### DIFF
--- a/clang/lib/CodeGen/CGClass.cpp
+++ b/clang/lib/CodeGen/CGClass.cpp
@@ -438,9 +438,12 @@ Address CodeGenFunction::GetAddressOfBaseClass(
   }
   else
   {
-    // Apply both offsets.
-    Value = ApplyNonVirtualAndVirtualOffset(*this, Value, NonVirtualOffset,
-                                          VirtualOffset, Derived, VBase);
+    // Apply both offsets, except for opaque client (anyref) classes, which do
+    // not need any offset.
+    if (!Derived->isClientNamespace()) {
+      Value = ApplyNonVirtualAndVirtualOffset(*this, Value, NonVirtualOffset,
+                                            VirtualOffset, Derived, VBase);
+    }
 
     // Cast to the destination type.
     Value = Builder.CreateElementBitCast(Value, BaseValueTy);

--- a/llvm/lib/CheerpUtils/FFIWrapping.cpp
+++ b/llvm/lib/CheerpUtils/FFIWrapping.cpp
@@ -36,7 +36,7 @@ static Function* wrapImport(Module& M, const Function* Orig)
 	CallInst* ForwardCall = Builder.CreateCall(const_cast<Function*>(Orig), params);
 	Type* RetTy = ForwardCall->getType();
 	Value* Ret = RetTy->isVoidTy() ? nullptr : ForwardCall;
-	if (Ret && RetTy->isPointerTy() && !TypeSupport::isAsmJSPointer(RetTy) && !TypeSupport::isClientType(RetTy))
+	if (Ret && RetTy->isPointerTy() && !TypeSupport::isAsmJSPointer(RetTy) && !TypeSupport::isClientType(RetTy->getPointerElementType()))
 	{
 		Function* MakeRegular = Intrinsic::getDeclaration(&M, Intrinsic::cheerp_make_regular, { RetTy, RetTy });
 		Function* PointerOffset = Intrinsic::getDeclaration(&M, Intrinsic::cheerp_pointer_offset, { RetTy });

--- a/llvm/lib/CheerpUtils/JSStringLiteralLowering.cpp
+++ b/llvm/lib/CheerpUtils/JSStringLiteralLowering.cpp
@@ -22,6 +22,10 @@ namespace cheerp
 
 PreservedAnalyses JSStringLiteralLoweringPass::run(Function& F, FunctionAnalysisManager& FAM)
 {
+	// Skip this pass for wasm functions, because we still need to call the
+	// String constructor to get an anyref object.
+	if (F.getSection() == "asmjs")
+		return PreservedAnalyses::all();
 	bool Changed = false;
 	for(Instruction& I: instructions(F))
 	{


### PR DESCRIPTION
Fixed the following issues:
1. Attempting to use virtual bases of a client class in wasm would result in an invalid GEP being generated, even though a simple bitcast is enough for opaque client types.
2. The wrappers generated by the FFIWrapping pass should use complete objects when returning pointers to client types, but it checked if the pointer itself is a client type, rather than the type that it points to. This would incorrectly result in a regular object being generated instead.
3. The JSStringLiteralLoweringPass was also being run on wasm functions, incorrectly replacing the string literal with a null pointer. We still need to call the string constructor to obtain an anyref object. The fix is to simply skip the pass for wasm functions.