### PR TITLE
Fix bugs in TypeSupport::isJSExportedType

### DIFF
--- a/llvm/include/llvm/Cheerp/JsExport.h
+++ b/llvm/include/llvm/Cheerp/JsExport.h
@@ -83,6 +83,7 @@ class JsExportRecord {
 public:
 	JsExportRecord(const llvm::Module& module, const llvm::MDNode* node);
 
+	llvm::StringRef getStructName() const;
 	JsExportName getName() const;
 	llvm::StructType* getType() const;
 	llvm::StructType* getBase() const;

--- a/llvm/include/llvm/Cheerp/Utility.h
+++ b/llvm/include/llvm/Cheerp/Utility.h
@@ -16,6 +16,7 @@
 #include <set>
 #include <string>
 #include <unordered_set>
+#include "llvm/ADT/StringSet.h"
 #include "llvm/Analysis/LoopInfo.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
@@ -576,7 +577,7 @@ public:
 		return cheerp::TypeSupport::getAlignmentAsmJS(dl, t) > 4? 8 : 4;
 	}
 private:
-	static std::optional<std::unordered_set<const llvm::StructType*>> jsExportedTypes;
+	static std::optional<llvm::StringSet<>> jsExportedTypes;
 	const llvm::Module & module;
 };
 

--- a/llvm/lib/CheerpUtils/JsExport.cpp
+++ b/llvm/lib/CheerpUtils/JsExport.cpp
@@ -70,6 +70,10 @@ namespace cheerp {
 		flags = llvm::cast<llvm::ConstantInt>(llvm::cast<llvm::ConstantAsMetadata>(node->getOperand(2))->getValue())->getZExtValue();
 	}
 
+	llvm::StringRef JsExportRecord::getStructName() const {
+		return type->getStructName();
+	}
+
 	JsExportName JsExportRecord::getName() const {
 		llvm::StringRef name = type->getStructName();
 

--- a/llvm/lib/CheerpUtils/Utility.cpp
+++ b/llvm/lib/CheerpUtils/Utility.cpp
@@ -744,14 +744,14 @@ bool TypeSupport::isJSExportedType(StructType* st, const Module& m)
 		return false;
 	if (!jsExportedTypes)
 	{
-		jsExportedTypes->emplace();
+		jsExportedTypes.emplace();
 		for (auto record : getJsExportRecords(m))
-			jsExportedTypes->insert(record.getType());
+			jsExportedTypes->insert(record.getStructName());
 	}
-	return jsExportedTypes->count(st);
+	return jsExportedTypes->contains(st->getStructName());
 }
 
-std::optional<std::unordered_set<const llvm::StructType*>> TypeSupport::jsExportedTypes;
+std::optional<llvm::StringSet<>> TypeSupport::jsExportedTypes;
 
 bool TypeSupport::isSimpleType(Type* t, bool forceTypedArrays)
 {


### PR DESCRIPTION
Tests were failing because of the wrong type of member access was used here, attempting to insert into the uninitialized set, instead of initializing the set:
```diff
-jsExportedTypes->emplace();
+jsExportedTypes.emplace();
```

After fixing this, another issue presented itself.

TypeOptimizer will sometimes create new instances of `StructType` to replace old ones. The new instances will have a different address, thereby invalidating the `TypeSupport::jsExportedTypes` set. I fixed this by storing the names of the structs instead of `StructType` pointers.

How come everything seemed to be working on my machine, despite these issues? No idea.

I'm marking this as ready for review, but let's wait for CI to finish before merging.