### PR TITLE
Fix global variable rewrite dropping asmjs section

### DIFF
--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -383,6 +383,7 @@ CodeGenFunction::AddInitializerToStaticVarDecl(const VarDecl &D,
     GV->setVisibility(OldGV->getVisibility());
     GV->setDSOLocal(OldGV->isDSOLocal());
     GV->setComdat(OldGV->getComdat());
+    GV->setSection(OldGV->getSection());
 
     // Steal the name of the old global
     GV->takeName(OldGV);


### PR DESCRIPTION
When clang finds an initializer that has a different type than the global variable that it is initializing, clang rewrites the global variable to have the same type as the initializer. A comment in the source code explains that

> We have to do this because some types, like unions, can't be completely represented in the LLVM type system.

While I'm not sure how to trigger this with union types, it can also be triggered with a function pointer type with an incomplete struct as a parameter. See the example below for details on how this happens.

The function that rewrites the global variable forgets to also copy over the section of the old global variable. This eventually leads to a crash in CheerpWasmWriter, which expects the global variable to be in the asmjs section.

```cpp
struct [[cheerp::jsexport]] Foo {
        // Foo is incomplete at this point. CodeGenTypes::isFuncTypeConvertible
        // will say that the function pointer type is not convertible because its
        // argument is incomplete. CodeGenTypes::ConvertType will return a dummy
        // type because the actual type is not convertible.
        void (*func)(Foo);
};

void func(Foo);

// [[cheerp::jsexport]] to prevent the compiler from removing the function
// entirely.
[[cheerp::jsexport]] Foo* get() {
        // This static variable is initially generated with type:
        //   %struct._Z3Foo = type asmjs { void ()* }
        // Where "void ()*" is the dummy function pointer type from before.
        // Now that Foo is complete, the type generated for the initializer does
        // have an accurate function pointer type:
        //   asmjs { void (%struct._Z3Foo*)* }
        // Clang detects the difference between the type of the variable and its
        // initializer in CodeGenFunction::AddInitializerToStaticVarDecl and
        // rewrites the global variable to use the same type as the initializer,
        // but forgets to also copy over the section of the old global variable.
        static Foo foo = { func };

        // Taking the address of the global variable here eventually results in
        // LinearMemoryHelper::getGlobalVariableAddress being called. This function
        // only looks at variables in the asmjs section. Because the section was
        // dropped when rewriting the variable, the lookup fails and results in a
        // crash.
        return &foo;
}
```