### PR TITLE
Fix GDA not visiting global operator delete

### DIFF
--- a/llvm/lib/CheerpUtils/GlobalDepsAnalyzer.cpp
+++ b/llvm/lib/CheerpUtils/GlobalDepsAnalyzer.cpp
@@ -1202,7 +1202,7 @@ void GlobalDepsAnalyzer::visitGlobal( const GlobalValue * C, VisitedSet & visite
 		}
 		else if (const Function * F = dyn_cast<Function>(C) )
 		{
-			if (isFreeFunctionName(C->getName()))
+			if (C->getName() == "free")
 			{
 				// Don't visit free right now. We do it only if
 				// actyally needed at the end


### PR DESCRIPTION
When GlobalDepsAnalyzer encounters a function where `isFreeFunctionName` returns true, that function is not visited immediately. Instead, a flag is set indicating that a function named "free" should be visited later, if needed.

When `isFreeFunctionName` returns true for a function whose name is not "free" (so "_ZdlPv" or "_ZdaPv"), that function will never be visited by GDA. This results in a crash when the function references any other global that is deleted as a result of the function, and its children, not being visited.

Example of a program that would crash:

```cpp
#include <cstdio>

void operator delete(void* ptr) noexcept {
        std::puts("test");
}

int main() {
        delete new int;
}
```

I don't see any point in defering visiting the global delete operators, so the solution is to simply replace the call to `isFreeFunctionName` so we only defer visiting the function named "free". Note that `isFreeFunctionName` is still used in other places where it should probably return true for the global delete operators as well.