### PR TITLE
Support unsigned pointers and large heap size

### DIFF
--- a/llvm/include/llvm/Cheerp/Writer.h
+++ b/llvm/include/llvm/Cheerp/Writer.h
@@ -427,6 +427,13 @@ private:
 		return useMathFround && coercionPrio != FROUND;
 	}
 	/**
+	 * Decide if we need to use unsigned integers to represent pointers.
+	 */
+	bool needsUnsignedPointers()
+	{
+		return heapSize > 2048;
+	}
+	/**
 	 * Return the next priority higher than `prio`.
 	 * For binary operators in general the rhs must increment the priority
 	 * if there are more operators with the same priority (e.g. FMul,FDiv,FRem)
@@ -435,6 +442,28 @@ private:
 	{
 		int new_prio = prio;
 		return static_cast<PARENT_PRIORITY>(++new_prio);
+	}
+	/**
+	 * Return the priority of a pointer coercion.
+	 */
+	PARENT_PRIORITY pointerCoercionPrio()
+	{
+		return needsUnsignedPointers() ? SHIFT : BIT_OR;
+	}
+	/**
+	 * Return the operator and right side of the expression used for pointer
+	 * coercions.
+	 */
+	llvm::StringRef pointerCoercionSuffix()
+	{
+		return needsUnsignedPointers() ? ">>>0" : "|0";
+	}
+	/**
+	 * Return the operator used for pointer right shifts.
+	 */
+	llvm::StringRef pointerShiftOperator()
+	{
+		return needsUnsignedPointers() ? ">>>" : ">>";
 	}
 
 	/**

--- a/llvm/lib/CheerpUtils/LinearMemoryHelper.cpp
+++ b/llvm/lib/CheerpUtils/LinearMemoryHelper.cpp
@@ -648,6 +648,8 @@ void LinearMemoryHelper::addStack()
 
 void LinearMemoryHelper::checkMemorySize()
 {
+	if (mode == FunctionAddressMode::AsmJS && memorySize > 2147483648U)
+		report_fatal_error("Cheerp: -cheerp-linear-heap-size greater than 2048 is not supported with -cheerp-linear-output=asmjs");
 	if (heapStart < memorySize)
 		return;
 	// Not enough memory, error

--- a/llvm/lib/CheerpWriter/CheerpWasmWriter.cpp
+++ b/llvm/lib/CheerpWriter/CheerpWasmWriter.cpp
@@ -4919,7 +4919,7 @@ void CheerpWasmWriter::compileGlobalSection()
 
 		// Start the stack from the end of default memory
 		stackTopGlobal = usedGlobals++;
-		uint32_t stackTop = linearHelper.getStackStart();
+		int32_t stackTop = linearHelper.getStackStart();
 
 		// There is the stack and the globalized constants
 		encodeULEB128(1 + globalizedConstantsTmp.size() + globalizedGlobalsIDs.size(), section);
@@ -5498,7 +5498,7 @@ void CheerpWasmWriter::WasmGepWriter::addConst(int64_t v)
 	// Just make sure that the constant part of the offset is not too big
 	// TODO: maybe use i64.const here instead of crashing
 	assert(v>=std::numeric_limits<int32_t>::min());
-	assert(v<=std::numeric_limits<int32_t>::max());
+	assert(v<=std::numeric_limits<uint32_t>::max());
 
 	constPart += v;
 }


### PR DESCRIPTION
When the heap size is greater than 2GB, pointers are converted to unsigned integers using the unsigned right shift ">>>" operator.

Also changed signedness of integers in some places to correctly handle values greater than the signed integer limit.

Related PRs:
https://github.com/leaningtech/cheerp-libs/pull/26
https://github.com/leaningtech/cheerp-utils/pull/74
https://github.com/leaningtech/cheerpos/pull/24