### PR TITLE
Fix getRegisterId called on unused PHI instruction

### DIFF
--- a/llvm/lib/CheerpWriter/CheerpWasmWriter.cpp
+++ b/llvm/lib/CheerpWriter/CheerpWasmWriter.cpp
@@ -4339,6 +4339,8 @@ std::map<const llvm::BasicBlock*, const llvm::PHINode*> CheerpWasmWriter::select
 		std::pair<int, const llvm::PHINode*> best{0, nullptr};
 		for (const PHINode& phi : BB->phis())
 		{
+			if (phi.use_empty())
+				continue;
 			std::pair<int, const llvm::PHINode*> curr{gainOfHandlingPhiOnTheEdge(&phi), &phi};
 			if (curr > best)
 				best = curr;


### PR DESCRIPTION
Do not use "use-less" PHI instructions as the result of CFG tokens. This results in a crash because the registerize pass does not assign registers to instructions with 0 users, so the `getRegisterId` lookup for the PHI instruction would fail.

This fixes the memprof issue.