### PR TITLE
Run InvokeWrappingPass before AllocaLoweringPass

### DIFF
--- a/llvm/lib/CheerpUtils/AllocaLowering.cpp
+++ b/llvm/lib/CheerpUtils/AllocaLowering.cpp
@@ -308,6 +308,7 @@ PreservedAnalyses cheerp::AllocaLoweringInnerPass::run(Function& F, FunctionAnal
 	PA.preserve<RegisterizeAnalysis>();
 	PA.preserve<GlobalDepsAnalysis>();
 	PA.preserve<DominatorTreeAnalysis>();
+	PA.preserve<InvokeWrappingAnalysis>();
 	return PA;
 }
 

--- a/llvm/lib/Target/CheerpBackend/CheerpWritePass.cpp
+++ b/llvm/lib/Target/CheerpBackend/CheerpWritePass.cpp
@@ -249,9 +249,9 @@ bool CheerpWritePass::runOnModule(Module& M)
 
   MPM.addPass(cheerp::FreeAndDeleteRemovalPass());
   MPM.addPass(cheerp::GlobalDepsAnalyzerPass(mathMode, /*resolveAliases*/true));
+  MPM.addPass(cheerp::InvokeWrappingPass());
   if (isWasmTarget)
     MPM.addPass(cheerp::AllocaLoweringPass());
-  MPM.addPass(cheerp::InvokeWrappingPass());
   MPM.addPass(cheerp::FFIWrappingPass());
   MPM.addPass(createModuleToFunctionPassAdaptor(cheerp::FixIrreducibleControlFlowPass()));
   MPM.addPass(createModuleToFunctionPassAdaptor(cheerp::PointerArithmeticToArrayIndexingPass()));


### PR DESCRIPTION
When rewriting calls to variadic functions, AllocaLowering only handles call instructions, not invoke instructions. By moving InvokeWrapping before AllocaLowering, the problematic invokes are converted to calls before AllocaLowering is run.

This fixes an issue with exceptions and variadic arguments:

```cpp
extern "C" {
        int printf(const char *__restrict, ...);
}
struct Struct
{
        static void func();
};

class ArgParse {
public:
        ~ArgParse ();
        int options (const char *intro, ...) /*noexcept*/;
};

int ArgParse::options (const char *intro, ...) /*noexcept*/
{
        __builtin_va_list ap;
        __builtin_va_start(ap, intro);
        const char *cur = __builtin_va_arg(ap, char *);
        printf("Variadic %s\n", cur);
        Struct::func();
        return 0;
}

void webMain()
{
        ArgParse ap;
        ap.options ("", "__GOOD__");
}
```

```
/opt/cheerp/bin/clang++ --target=cheerp-wasm -O2 -o test.js test.cpp -cheerp-pretty-code -fexceptions && nodejs test.js
```

Before: `Variadic (null)`
After: `Variadic __GOOD__`