### PR TITLE
Fix spurious warning about cast of unrelated types

### DIFF
--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -1079,7 +1079,7 @@ Address CodeGenFunction::EmitPointerWithAlignment(const Expr *E,
             *TBAAInfo = CGM.mergeTBAAInfoForCast(*TBAAInfo,
                                                  TargetTypeTBAAInfo);
 	  const ExplicitCastExpr *ECE = cast<ExplicitCastExpr>(CE);
-	  if ((CGM.getTarget().isByteAddressable()==false) && ECE->getSubExpr()->getType() != ECE->getType()) {
+	  if ((CGM.getTarget().isByteAddressable()==false) && !getContext().hasSameType(ECE->getSubExpr()->getType(), ECE->getType())) {
             bool asmjs = CurFn->getSection()==StringRef("asmjs");
             llvm::Function* intrinsic = CGM.GetUserCastIntrinsic(ECE,
               ECE->getSubExpr()->getType(),


### PR DESCRIPTION
Fixed a spurious warning about cast of unrelated types, as seen in this example program (Commenting out the namespace declaration on line 9 causes the warning not to appear):
```cpp
#include <cheerp/types.h>

class CString {
public:
        [[cheerp::genericjs]]
        explicit operator client::String*() const;
};

namespace [[cheerp::genericjs]] client {}

[[cheerp::genericjs]]
client::Object* foo() {
        CString string;
        return static_cast<client::String*>(string);
}
```

Produces the warning:
```
test.cpp:14:16: warning: Cheerp: Using values cast to unrelated types is undefined behaviour unless the destination type is the actual type of the value [-Wcheerp-unsafe]
        return static_cast<client::String*>(string);
               ^
```

I believe the issue occurs because the `client::String` type spelled in the declaration of `operator client::String*` on line 6 is not the exact same type has the one in the `static_cast` on line 14. However, they do have the same canonical type.

I looked at a few different functions in `ASTContext` to compare the types in a better way. The one that seems to make the most sense is `hasSameType`, which internally calls `getCanonicalType` on both arguments and just does an `==` comparison on the resulting pointers.