### PR TITLE
Prevent collapsing of secondary bases used inside a hierarchy where a downcast is done

### DIFF
--- a/llvm/include/llvm/Cheerp/TypeOptimizer.h
+++ b/llvm/include/llvm/Cheerp/TypeOptimizer.h
@@ -120,6 +120,7 @@ private:
 
 	llvm::Module* module;
 	const llvm::DataLayout* DL;
+	std::unordered_set<const llvm::Type*> uncollapsibleSecondaryBases;
 	std::unordered_map<const llvm::StructType*,std::set<llvm::StructType*>> downcastSourceToDestinationsMapping;
 	std::unordered_map<const llvm::StructType*, std::vector<std::pair<uint32_t, uint32_t>>> membersMappingData;
 	std::unordered_map<llvm::GlobalValue*, llvm::Constant*> globalsMapping;


### PR DESCRIPTION
When a class is used inside a hierarchy where a downcast is performed on it cannot be collapsed. If it is collapsed the offset given by the downcast builtin will no longer be correct, causing unexpected behavior