### PR TITLE
Fix: no longer use the variable name inside the same object when creating a nested complex type

### DIFF
--- a/llvm/lib/CheerpWriter/Types.cpp
+++ b/llvm/lib/CheerpWriter/Types.cpp
@@ -294,9 +294,9 @@ uint32_t CheerpWriter::compileComplexType(Type* t, COMPILE_TYPE_STYLE style, Str
 				compileSimpleType(element, init);
 			}
 			else if(style == THIS_OBJ)
-				compileComplexType(element, LITERAL_OBJ, varName, nextMaxDepth, 0, offsetToValueMap, totalOffset, usedValuesFromMap);
+				compileComplexType(element, LITERAL_OBJ, llvm::StringRef(""), nextMaxDepth, 0, offsetToValueMap, totalOffset, usedValuesFromMap);
 			else
-				numElements += compileComplexType(element, LITERAL_OBJ, varName, nextMaxDepth, totalLiteralProperties + numElements, offsetToValueMap, totalOffset, usedValuesFromMap);
+				numElements += compileComplexType(element, LITERAL_OBJ, llvm::StringRef(""), nextMaxDepth, totalLiteralProperties + numElements, offsetToValueMap, totalOffset, usedValuesFromMap);
 			if(useWrapperArray)
 			{
 				if(restoreMaxDepth)
@@ -368,7 +368,7 @@ uint32_t CheerpWriter::compileComplexType(Type* t, COMPILE_TYPE_STYLE style, Str
 					compileSimpleType(element, init);
 				}
 				else
-					numElements += compileComplexType(element, LITERAL_OBJ, varName, nextMaxDepth, totalLiteralProperties + numElements, offsetToValueMap, totalOffset, usedValuesFromMap);
+					numElements += compileComplexType(element, LITERAL_OBJ, llvm::StringRef(""), nextMaxDepth, totalLiteralProperties + numElements, offsetToValueMap, totalOffset, usedValuesFromMap);
 			}
 			stream << ']';
 		}


### PR DESCRIPTION
Previously, complex types were formatted with the variable name inside if there was a nested complex type:
tmp={i0:0, i1:0, a2:tmp={i0:0, i1:0}};

This PR removes the variable name:
tmp={i0:0, i1:0, a2:{i0:0, i1:0}};