### PR TITLE
Relax the front-end check for realloc

### DIFF
--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -21132,7 +21132,8 @@ void Sema::CheckCheerpFFICall(const FunctionDecl* Parent, const FunctionDecl* FD
   // Allow some builtins in any case, since they will become intrinsics
   if (FDecl->getBuiltinID() == Builtin::BImemcpy ||
       FDecl->getBuiltinID() == Builtin::BImemmove ||
-      FDecl->getBuiltinID() == Builtin::BImemset)
+      FDecl->getBuiltinID() == Builtin::BImemset ||
+      FDecl->getBuiltinID() == Builtin::BIrealloc)
     return;
   if (Parent->hasAttr<GenericJSAttr>() && FDecl->hasAttr<AsmJSAttr>()) {
     auto p = FDecl->parameters().begin();


### PR DESCRIPTION
This PR adds the realloc builtin to the list of allowed builtins.

Previously trying to call realloc inside a genericjs function like this:
```
class [[cheerp::genericjs]] testReallocClass
{
    public:
        int a;
        int b;
};

[[cheerp::genericjs]]
void testRealloc()
{
    testReallocClass* allocA = NULL;
    testReallocClass* allocB = NULL;
    int size = 5;

    allocA = (testReallocClass*) realloc((testReallocClass*)NULL, size);
    allocB = (testReallocClass*) realloc(allocA, size * 2);
}
```

Would result in an error when compiling with "-target cheerp-wasm":
```
error: Cheerp: Cannot call function 'realloc'  with attribute 'wasm' from function 'testRealloc' with attribute 'genericjs', because parameter '' is a pointer to a basic type
    allocA = (testReallocClass*) realloc((testReallocClass*)NULL, size);
```