### PR TITLE
Fix equal pointers comparison when there is a GEP with more than 2 operands

### DIFF
--- a/llvm/lib/CheerpUtils/Utility.cpp
+++ b/llvm/lib/CheerpUtils/Utility.cpp
@@ -280,7 +280,7 @@ bool InlineableCache::isInlineableImpl(const Instruction& I)
 		if (IPointerKind == COMPLETE_OBJECT) {
 			auto type = cast<GetElementPtrInst>(I).getResultElementType();
 			// Always inline geps to immutable fields of a complete object.
-			if (TypeSupport::isImmutableType(type))
+			if (TypeSupport::isImmutableType(type) || getGEPContainerType(&I)->isArrayTy())
 				return true;
 
 			return !hasMoreThan1Use;


### PR DESCRIPTION
adds a check to see if a GEP with more then 2 operands is done on a pointer or an array, if this is the case we can compare the pointer/array and its offset directly without dereferencing the pointers