### PR TITLE
Fix vector example

### DIFF
--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -21172,7 +21172,7 @@ void Sema::CheckCheerpFFICall(const FunctionDecl* Parent, const FunctionDecl* FD
           d << "variadic";
 
         d << "pointer";
-      } else if (pt && pt->isReferenceType() && pt->getPointeeType()->isFundamentalType()) {
+      } else if (pt && pt->isReferenceType() && (pt->getPointeeType()->isFundamentalType() || pt->getPointeeType()->isPointerType())) {
         Diag((*a)->getBeginLoc(), diag::err_cheerp_wrong_basic_pointer_param)
           << FDecl << FDecl->getAttr<AsmJSAttr>()
           << Parent << Parent->getAttr<GenericJSAttr>()

--- a/llvm/lib/CheerpUtils/PointerAnalyzer.cpp
+++ b/llvm/lib/CheerpUtils/PointerAnalyzer.cpp
@@ -429,6 +429,15 @@ bool PointerUsageVisitor::visitRawChain( const Value * p)
 		{
 			return true;
 		}
+		else if (const SelectInst* si = dyn_cast<SelectInst>(p))
+		{
+			bool allRawOperands = true;
+			for (unsigned int i = 1; i < si->getNumOperands(); i++)
+				if (!visitRawChain(si->getOperand(i)))
+					allRawOperands = false;
+			if (allRawOperands)
+				return true;
+		}
 		top = cast<Instruction>(p)->getParent()->getParent();
 	}
 	else if (isa<Argument>(p) )


### PR DESCRIPTION
Fixed two issues that are made apparent by the following program:

```cpp
#include <iostream>

class Obj {};

[[cheerp::genericjs]]
int webMain() {
	std::vector<Obj*> vec;

	vec.push_back(new Obj); // [1]

	std::cout << (int)vec[0] << std::endl;

	if (vec[0] == new Obj) { // [2]
		std::cout << "IDENTICAL" << std::endl;
	} else {
		std::cout << "NOT IDENTICAL" << std::endl;
	}

	return 0;
}
```

At [1], the call to `push_back` (a wasm function) should produce a diagnostic because it takes a reference to a pointer.

At [2], the if statement is compiled down to a `select` instruction, and the strings passed to `operator<<` are in linear memory. But PA did not follow the operands and would not discover the strings to be in linear memory.