### PR TITLE
Fix global initialization in WASI

### DIFF
--- a/clang/lib/CodeGen/CGDeclCXX.cpp
+++ b/clang/lib/CodeGen/CGDeclCXX.cpp
@@ -848,6 +848,9 @@ CodeGenModule::EmitCXXGlobalInitFunc() {
       llvm::Function *Fn = CreateGlobalInitOrCleanUpFunction(
           FTy, "_GLOBAL__I_" + getPrioritySuffix(Priority), FI);
 
+      if (Context.getTargetInfo().getTriple().getEnvironment() == llvm::Triple::WebAssembly)
+        Fn->setSection("asmjs");
+
       // Prepend the module inits to the highest priority set.
       if (!ModuleInits.empty()) {
         for (auto *F : ModuleInits)


### PR DESCRIPTION
```cpp
#include <iostream>

int main() {
        std::cout << "Hello, World!" << std::endl;
        return 0;
}
```

```
$ /opt/cheerp/bin/clang++ test.cpp -o test.wasm -target cheerp-wasm-wasi
$ wasmtime test.wasm
Error: failed to run main module `test.wasm`

Caused by:
    0: failed to instantiate "test.wasm"
    1: unknown import: `i::_GLOBAL__I_000101` has not been defined
```

The above error occurs because of two issues:
1. There is a genericjs `Exception::allocator` global present in the wasm libs, the initialization of which was done by pre-executor before, but now fails because the pre-executor does not handle a threading intrinsic.
2. Even if the wasm libs only contain wasm globals, the entry point for global initialization was being put in genericjs.

Because of these issues, any WASI program with globals that could not be pre-executed would fail with the above error. This PR fixes both issues. Note that no changes are made to pre-executor, it will still fail to initialize some gloals due to unhandled intrinsics. But this will no longer be a problem as, with these fixes, they can now be initialized at runtime in WASI.