### PR TITLE
Fix inconsistent base padding

### DIFF
--- a/clang/lib/CodeGen/CGClass.cpp
+++ b/clang/lib/CodeGen/CGClass.cpp
@@ -39,6 +39,7 @@ ComputeNonVirtualBaseClassGepPath(CodeGenModule& CGM,
                                   const CXXRecordDecl *DerivedClass,
                                   llvm::ArrayRef<const CXXRecordDecl*> BasePath) {
   const CXXRecordDecl *RD = DerivedClass;
+  const CXXRecordDecl *TopRD = DerivedClass;
   // Compute the expected type of the GEP expression
   llvm::Type* ret = nullptr;
 
@@ -47,11 +48,12 @@ ComputeNonVirtualBaseClassGepPath(CodeGenModule& CGM,
     if(!BaseDecl->isEmpty() && !ASTLayout.getBaseClassOffset(BaseDecl).isZero())
     {
       // Get the layout.
-      const CGRecordLayout &Layout = CGM.getTypes().getCGRecordLayout(RD);
+      const CGRecordLayout &Layout = CGM.getTypes().getCGRecordLayout(TopRD);
       uint32_t index=Layout.getNonVirtualBaseLLVMFieldNo(BaseDecl);
 
       GEPIndexes.push_back(llvm::ConstantInt::get(CGM.Int32Ty, index));
       ret = Layout.getLLVMType()->getElementType(index);
+      TopRD = BaseDecl;
     }
     RD = BaseDecl;
   }

--- a/clang/lib/CodeGen/CGRecordLayout.h
+++ b/clang/lib/CodeGen/CGRecordLayout.h
@@ -236,6 +236,13 @@ public:
 
   typedef  llvm::DenseMap<const CXXRecordDecl *, unsigned>::const_iterator const_base_iterator;
 
+  const_base_iterator nvbases_begin() const {
+        return NonVirtualBases.begin();
+  }
+  const_base_iterator nvbases_end() const {
+        return NonVirtualBases.end();
+  }
+
   const_base_iterator vbases_begin() const {
         return CompleteObjectVirtualBases.begin();
   }


### PR DESCRIPTION
When inlining fields of a direct base class, extra padding would sometimes be added to ensure fields in the derived class are at the same offset as they are in the base class, even if one is packed and the other isn't.

While this extra padding makes sure that fields end up at the same byte offset, the extra padding fields do shift the index of some fields. The `ComputeNonVirtualBaseClassGepPath` function in `CGClass.cpp` did not properly take into account the possibility these fields having a different index when inlined into a derived class.

This is fixed by also adding base classes of the direct base of a derived class into the derived class' `NonVirtualBases` map.