### PR TITLE
feat: exception handling rework: unwind argument as integer.

### DIFF
--- a/clang/lib/CodeGen/CGObjCRuntime.cpp
+++ b/clang/lib/CodeGen/CGObjCRuntime.cpp
@@ -241,6 +241,11 @@ void CGObjCRuntime::EmitTryCatchStmt(CodeGenFunction &CGF,
     }
 
     llvm::Value *RawExn = CGF.getExceptionFromSlot();
+    // In Cheerp Exn has type int, but the ObjC runtime expects void*.
+    // Just add an inttoptr here, we are doing it just to pass tests
+    if (CGM.getLangOpts().Cheerp) {
+      RawExn = CGF.Builder.CreateIntToPtr(RawExn, CGM.VoidPtrTy);
+    }
 
     // Enter the catch.
     llvm::Value *Exn = RawExn;

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -2010,7 +2010,7 @@ public:
 
   /// Get the named landingpad/resume type (Cheerp)
   llvm::StructType* GetLandingPadTy() {
-    if (getTarget().isByteAddressable()) {
+    if(!getLangOpts().Cheerp) {
       return llvm::StructType::get(Int8PtrTy, Int32Ty);
     }
     auto* Ret = llvm::StructType::getTypeByName(CGM.getLLVMContext(), "struct._ZN10__cxxabiv119__cheerp_landingpadE");

--- a/compiler-rt/lib/asan/asan_interceptors.cpp
+++ b/compiler-rt/lib/asan/asan_interceptors.cpp
@@ -349,8 +349,13 @@ extern "C" void __cxa_throw_wasm(void *a, void *b, void *c) {
 #endif
 
 
+#ifdef __CHEERP__
+#define UNWIND_ARG_TYPE int
+#else
+#define UNWIND_ARG_TYPE void*
+#endif
 #if ASAN_INTERCEPT___CXA_RETHROW_PRIMARY_EXCEPTION
-INTERCEPTOR(void, __cxa_rethrow_primary_exception, void *a) {
+INTERCEPTOR(void, __cxa_rethrow_primary_exception, UNWIND_ARG_TYPE a) {
   __asan_handle_no_return();
   REAL(__cxa_rethrow_primary_exception)(a);
 }

--- a/compiler-rt/lib/asan/asan_interceptors.h
+++ b/compiler-rt/lib/asan/asan_interceptors.h
@@ -172,7 +172,7 @@ DECLARE_REAL(size_t, mbstowcs, wchar_t *dest, const char *src, size_t len);
 DECLARE_REAL(size_t, mbsrtowcs, wchar_t *dest, const char **src, size_t len, void *ps);
 
 extern "C" void __cheerp___cxa_throw(void *, void *, void *);
-extern "C" void __cheerp___cxa_rethrow_primary_exception(void*);
+extern "C" void __cheerp___cxa_rethrow_primary_exception(int);
 #endif // SANITIZER_CHEERPWASM
 
 #  if !SANITIZER_APPLE

--- a/libcxx/include/exception
+++ b/libcxx/include/exception
@@ -187,7 +187,12 @@ _LIBCPP_NORETURN _LIBCPP_FUNC_VIS void rethrow_exception(exception_ptr);
 
 class _LIBCPP_TYPE_VIS exception_ptr
 {
-    void* __ptr_;
+#ifdef __CHEERP__
+    unsigned
+#else
+    void*
+#endif
+    __ptr_;
 public:
     _LIBCPP_INLINE_VISIBILITY exception_ptr() _NOEXCEPT : __ptr_() {}
     _LIBCPP_INLINE_VISIBILITY exception_ptr(nullptr_t) _NOEXCEPT : __ptr_() {}
@@ -197,7 +202,7 @@ public:
     ~exception_ptr() _NOEXCEPT;
 
     _LIBCPP_INLINE_VISIBILITY explicit operator bool() const _NOEXCEPT
-    {return __ptr_ != nullptr;}
+    {return __ptr_ != 0;}
 
     friend _LIBCPP_INLINE_VISIBILITY
     bool operator==(const exception_ptr& __x, const exception_ptr& __y) _NOEXCEPT

--- a/libcxx/src/support/runtime/exception_pointer_cxxabi.ipp
+++ b/libcxx/src/support/runtime/exception_pointer_cxxabi.ipp
@@ -47,7 +47,7 @@ _LIBCPP_NORETURN
 void
 nested_exception::rethrow_nested() const
 {
-    if (__ptr_ == nullptr)
+    if (__ptr_ == 0)
         terminate();
     rethrow_exception(__ptr_);
 }

--- a/libcxxabi/include/cxxabi.h
+++ b/libcxxabi/include/cxxabi.h
@@ -146,15 +146,21 @@ extern _LIBCXXABI_FUNC_VIS char *__cxa_demangle(const char *mangled_name,
                                                 char *output_buffer,
                                                 size_t *length, int *status);
 
+#ifdef __CHEERP__
+#define UNWIND_TY int
+#else
+#define UNWIND_TY void*
+#endif
+
 // Apple additions to support C++ 0x exception_ptr class
 // These are primitives to wrap a smart pointer around an exception object
-extern _LIBCXXABI_FUNC_VIS void *__cxa_current_primary_exception() throw();
+extern _LIBCXXABI_FUNC_VIS UNWIND_TY __cxa_current_primary_exception() throw();
 extern _LIBCXXABI_FUNC_VIS void
-__cxa_rethrow_primary_exception(void *primary_exception);
+__cxa_rethrow_primary_exception(UNWIND_TY primary_exception);
 extern _LIBCXXABI_FUNC_VIS void
-__cxa_increment_exception_refcount(void *primary_exception) throw();
+__cxa_increment_exception_refcount(UNWIND_TY primary_exception) throw();
 extern _LIBCXXABI_FUNC_VIS void
-__cxa_decrement_exception_refcount(void *primary_exception) throw();
+__cxa_decrement_exception_refcount(UNWIND_TY primary_exception) throw();
 
 // Apple extension to support std::uncaught_exception()
 extern _LIBCXXABI_FUNC_VIS bool __cxa_uncaught_exception() throw();

--- a/llvm/lib/CheerpUtils/InvokeWrapping.cpp
+++ b/llvm/lib/CheerpUtils/InvokeWrapping.cpp
@@ -56,9 +56,8 @@ static GlobalVariable* getOrInsertLPHelperGlobal(Module& M)
 	assert(Ty);
 	GlobalVariable* G = cast<GlobalVariable>(M.getOrInsertGlobal("__cheerpLandingPadHelperGlobal", Ty, [&M, Ty]()
 	{
-		auto* g = new GlobalVariable(M, Ty, false, GlobalVariable::ExternalLinkage, UndefValue::get(Ty));
-		g->setName("__cheerpLandingPadHelperGlobal");
-		g->setLinkage(GlobalVariable::ExternalLinkage);
+		unsigned AS = 0;
+		auto* g = new GlobalVariable(M, Ty, false, GlobalVariable::ExternalLinkage, UndefValue::get(Ty), "__cheerpLandingPadHelperGlobal", nullptr, GlobalVariable::NotThreadLocal, AS);
 		if (Ty->hasAsmJS())
 			g->setSection("asmjs");
 		return g;
@@ -71,10 +70,8 @@ static GlobalVariable* getOrInsertCondHelperGlobal(Module& M)
     auto* Ty = IntegerType::get(M.getContext(), 32);
 	GlobalVariable* G = cast<GlobalVariable>(M.getOrInsertGlobal("__cheerpInvokeHelperGlobal", Ty, [&M, Ty]()
 	{
-		auto* g = new GlobalVariable(M, Ty, false, GlobalVariable::ExternalLinkage, UndefValue::get(Ty));
-		g->setName("__cheerpInvokeHelperGlobal");
-		g->setLinkage(GlobalVariable::ExternalLinkage);
 		GlobalVariable* LPHelper = getOrInsertLPHelperGlobal(M);
+		auto* g = new GlobalVariable(M, Ty, false, GlobalVariable::ExternalLinkage, UndefValue::get(Ty), "__cheerpInvokeHelperGlobal", nullptr, GlobalVariable::NotThreadLocal, LPHelper->getAddressSpace());
 		g->setSection(LPHelper->getSection());
 		return g;
 	}));
@@ -363,18 +360,11 @@ static Function* wrapInvoke(Module& M, InvokeInst& IV, DenseSet<Instruction*>& T
 
 static Function* wrapResume(Module& M, ResumeInst* RS)
 {
-	PointerType* Int8PtrTy = Type::getInt8Ty(M.getContext())->getPointerTo(0);
 	Function* CxaResume = M.getFunction("__cxa_resume");
 	assert(CxaResume);
 	IRBuilder<> Builder(RS);
 	Value* LP = RS->getOperand(0);
 	Value* Val = Builder.CreateExtractValue(LP, {0});
-    if (Triple(M.getTargetTriple()).isCheerpWasm()) {
-      Val = Builder.CreateIntToPtr(Val, Int8PtrTy);
-    } else {
-		llvm::Function *MakeReg = Intrinsic::getDeclaration(&M, Intrinsic::cheerp_make_regular, {Int8PtrTy, Int8PtrTy});
-		Val = Builder.CreateCall(MakeReg, {ConstantPointerNull::get(Int8PtrTy), Val});
-	}
 	Value* Call = Builder.CreateCall(CxaResume->getFunctionType(), CxaResume, Val);
 	RS->replaceAllUsesWith(Call);
 	Builder.CreateUnreachable();


### PR DESCRIPTION
Instead of using void* to represent the unwind argument, switch to using an int. The argument was really just an int all along ,and we were pretending it was a pointer to conform to the ABI. Future changes related to Address Spaces will require changes to the ABI anyway (the pointer would need an address space, probably multiple), so the least painful option is to just use int.