### PR TITLE
Fix alignment of wasm loads and stores

### DIFF
--- a/llvm/include/llvm/Cheerp/WasmWriter.h
+++ b/llvm/include/llvm/Cheerp/WasmWriter.h
@@ -531,7 +531,8 @@ public:
 	void compileICmp(const llvm::ICmpInst& ci, const llvm::CmpInst::Predicate p, WasmBuffer& code);
 	void compileICmp(const llvm::Value* op0, const llvm::Value* op1, const llvm::CmpInst::Predicate p, WasmBuffer& code);
 	void compileFCmp(const llvm::Value* lhs, const llvm::Value* rhs, const llvm::CmpInst::Predicate p, WasmBuffer& code);
-	void encodeLoad(llvm::Type* ty, uint32_t offset, WasmBuffer& code, bool signExtend, bool atomic);
+	void encodeLoad(llvm::Type* ty, uint32_t offset, llvm::Align align, WasmBuffer& code, bool signExtend, bool atomic);
+	void encodeStore(llvm::Type* ty, uint32_t offset, llvm::Align align, WasmBuffer& code, bool atomic);
 	void encodeWasmIntrinsic(WasmBuffer& code, const llvm::Function* F);
 	void encodeBranchTable(WasmBuffer& code, std::vector<uint32_t> table, int32_t defaultBlock);
 	void encodeDataSectionChunk(WasmBuffer& data, uint32_t address, llvm::StringRef buf);


### PR DESCRIPTION
Use the alignment from LLVM loads and stores when generating wasm loads and stores, instead of always using the "natural" type alignment. This also bumps the alignment of i64 loads and stores to 8 bytes, which were hardcoded to have 4 byte alignment before.