### PR TITLE
clang: add cheerp language address spaces (NFC)

### DIFF
--- a/clang/include/clang/Basic/AddressSpaces.h
+++ b/clang/include/clang/Basic/AddressSpaces.h
@@ -59,6 +59,12 @@ enum class LangAS : unsigned {
   // HLSL specific address spaces.
   hlsl_groupshared,
 
+  // Cheerp specific address spaces.
+  cheerp_client,
+  cheerp_genericjs,
+  cheerp_bytelayout,
+  cheerp_wasm,
+
   // This denotes the count of language-specific address spaces and also
   // the offset added to the target-specific address spaces, which are usually
   // specified by address space attributes __attribute__(address_space(n))).

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -956,6 +956,10 @@ static const LangASMap *getAddressSpaceMap(const TargetInfo &T,
         11, // ptr32_uptr
         12, // ptr64
         13, // hlsl_groupshared
+        14, // cheerp_client
+        15, // cheerp_genericjs
+        16, // cheerp_bytelayout
+        17, // cheerp_wasm
     };
     return &FakeAddrSpaceMap;
   } else {

--- a/clang/lib/AST/TypePrinter.cpp
+++ b/clang/lib/AST/TypePrinter.cpp
@@ -2232,6 +2232,14 @@ std::string Qualifiers::getAddrSpaceAsString(LangAS AS) {
     return "__ptr64";
   case LangAS::hlsl_groupshared:
     return "groupshared";
+  case LangAS::cheerp_client:
+    return "__client";
+  case LangAS::cheerp_genericjs:
+    return "__js";
+  case LangAS::cheerp_bytelayout:
+    return "__bl";
+  case LangAS::cheerp_wasm:
+    return "__wasm";
   default:
     return std::to_string(toTargetAddressSpace(AS));
   }

--- a/clang/lib/Basic/Targets/AMDGPU.cpp
+++ b/clang/lib/Basic/Targets/AMDGPU.cpp
@@ -57,6 +57,10 @@ const LangASMap AMDGPUTargetInfo::AMDGPUDefIsGenMap = {
     Generic,  // ptr32_uptr
     Generic,  // ptr64
     Generic,  // hlsl_groupshared
+    Generic,  // cheerp_client
+    Generic,  // cheerp_genericjs
+    Generic,  // cheerp_bl
+    Generic,  // cheerp_wasm
 };
 
 const LangASMap AMDGPUTargetInfo::AMDGPUDefIsPrivMap = {
@@ -81,7 +85,10 @@ const LangASMap AMDGPUTargetInfo::AMDGPUDefIsPrivMap = {
     Generic, // ptr32_uptr
     Generic, // ptr64
     Generic, // hlsl_groupshared
-
+    Generic,  // cheerp_client
+    Generic,  // cheerp_genericjs
+    Generic,  // cheerp_bl
+    Generic,  // cheerp_wasm
 };
 } // namespace targets
 } // namespace clang

--- a/clang/lib/Basic/Targets/DirectX.h
+++ b/clang/lib/Basic/Targets/DirectX.h
@@ -42,6 +42,10 @@ static const unsigned DirectXAddrSpaceMap[] = {
     0, // ptr32_uptr
     0, // ptr64
     3, // hlsl_groupshared
+    0,  // cheerp_client
+    0,  // cheerp_genericjs
+    0,  // cheerp_bl
+    0,  // cheerp_wasm
 };
 
 class LLVM_LIBRARY_VISIBILITY DirectXTargetInfo : public TargetInfo {

--- a/clang/lib/Basic/Targets/NVPTX.h
+++ b/clang/lib/Basic/Targets/NVPTX.h
@@ -44,6 +44,10 @@ static const unsigned NVPTXAddrSpaceMap[] = {
     0, // ptr32_uptr
     0, // ptr64
     0, // hlsl_groupshared
+    0,  // cheerp_client
+    0,  // cheerp_genericjs
+    0,  // cheerp_bl
+    0,  // cheerp_wasm
 };
 
 /// The DWARF address class. Taken from

--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -44,6 +44,10 @@ static const unsigned SPIRDefIsPrivMap[] = {
     0, // ptr32_uptr
     0, // ptr64
     0, // hlsl_groupshared
+    0,  // cheerp_client
+    0,  // cheerp_genericjs
+    0,  // cheerp_bl
+    0,  // cheerp_wasm
 };
 
 // Used by both the SPIR and SPIR-V targets.
@@ -74,6 +78,10 @@ static const unsigned SPIRDefIsGenMap[] = {
     0, // ptr32_uptr
     0, // ptr64
     0, // hlsl_groupshared
+    0,  // cheerp_client
+    0,  // cheerp_genericjs
+    0,  // cheerp_bl
+    0,  // cheerp_wasm
 };
 
 // Base class for SPIR and SPIR-V target info.

--- a/clang/lib/Basic/Targets/TCE.h
+++ b/clang/lib/Basic/Targets/TCE.h
@@ -51,6 +51,10 @@ static const unsigned TCEOpenCLAddrSpaceMap[] = {
     0, // ptr32_uptr
     0, // ptr64
     0, // hlsl_groupshared
+    0,  // cheerp_client
+    0,  // cheerp_genericjs
+    0,  // cheerp_bl
+    0,  // cheerp_wasm
 };
 
 class LLVM_LIBRARY_VISIBILITY TCETargetInfo : public TargetInfo {

--- a/clang/lib/Basic/Targets/WebAssembly.h
+++ b/clang/lib/Basic/Targets/WebAssembly.h
@@ -188,6 +188,33 @@ protected:
                         MacroBuilder &Builder) const override;
 };
 
+static const unsigned CheerpAddrSpaceMap[] = {
+    0,   // Default
+    0,   // opencl_global
+    0,   // opencl_local
+    0,   // opencl_constant
+    0,   // opencl_private
+    0,   // opencl_generic
+    0,   // opencl_global_device
+    0,   // opencl_global_host
+    0,   // cuda_device
+    0,   // cuda_constant
+    0,   // cuda_shared
+    0,   // sycl_global
+    0,   // sycl_global_device
+    0,   // sycl_global_host
+    0,   // sycl_local
+    0,   // sycl_private
+    0, // ptr32_sptr
+    0, // ptr32_uptr
+    0, // ptr64
+    0,   // hlsl_groupshared
+    0,  // cheerp_client
+    0,  // cheerp_genericjs
+    0,  // cheerp_bl
+    0,  // cheerp_wasm
+};
+
 // Cheerp base class
 class CheerpTargetInfo : public TargetInfo {
 private:
@@ -223,6 +250,7 @@ public:
     // We don't have multiple asm variants, and we want to be able to use
     // '{' and '}' in the asm code
     NoAsmVariants = true;
+    AddrSpaceMap = & CheerpAddrSpaceMap;
   }
 
   virtual ArrayRef<Builtin::Info> getTargetBuiltins() const override;

--- a/clang/lib/Basic/Targets/X86.h
+++ b/clang/lib/Basic/Targets/X86.h
@@ -45,6 +45,10 @@ static const unsigned X86AddrSpaceMap[] = {
     271, // ptr32_uptr
     272, // ptr64
     0,   // hlsl_groupshared
+    0,  // cheerp_client
+    0,  // cheerp_genericjs
+    0,  // cheerp_bl
+    0,  // cheerp_wasm
 };
 
 // X86 target abstract base class; x86-32 and x86-64 are very close, so

--- a/clang/test/SemaTemplate/address_space-dependent.cpp
+++ b/clang/test/SemaTemplate/address_space-dependent.cpp
@@ -43,7 +43,7 @@ void neg() {
 
 template <long int I>
 void tooBig() {
-  __attribute__((address_space(I))) int *bounds; // expected-error {{address space is larger than the maximum supported (8388587)}}
+  __attribute__((address_space(I))) int *bounds; // expected-error {{address space is larger than the maximum supported (8388583)}}
 }
 
 template <long int I>
@@ -101,7 +101,7 @@ int main() {
   car<1, 2, 3>(); // expected-note {{in instantiation of function template specialization 'car<1, 2, 3>' requested here}}
   HasASTemplateFields<1> HASTF;
   neg<-1>(); // expected-note {{in instantiation of function template specialization 'neg<-1>' requested here}}
-  correct<0x7FFFEB>();
+  correct<0x7FFFE7>();
   tooBig<8388650>(); // expected-note {{in instantiation of function template specialization 'tooBig<8388650L>' requested here}}
 
   __attribute__((address_space(1))) char *x;


### PR DESCRIPTION
This commit introduces the cheerp address spaces in clang (client, genericjs, bytelayout, wasm).
They are still not used anywhere, just declared, and mapped to LLVM address space 0 for all targets.