### PR TITLE
PointerPasses: only delete operand when it is safe

### DIFF
--- a/llvm/lib/CheerpUtils/PointerPasses.cpp
+++ b/llvm/lib/CheerpUtils/PointerPasses.cpp
@@ -553,7 +553,7 @@ static void deleteInstructionAndUnusedOperands(Instruction* I)
 	{
 		if(Instruction* opI = dyn_cast<Instruction>(op))
 		{
-			if(opI->hasOneUse())
+			if(opI->hasOneUse() && opI->isSafeToRemove())
 				operandsToErase.push_back(opI);
 		}
 	}


### PR DESCRIPTION
The deleteInstructionAndUnusedOperands function would unconditionally delete instructions if they only had one use, that use being the instruction that was being deleted by the pass. Now There is a check to prevent instructions with side effects from being removed.