### PR TITLE
Revert 8e10a60a8e5de52a6b8a1d4bca6bc0c0b6a1982f and fix the original issue

### DIFF
--- a/llvm/include/llvm/Cheerp/TypeOptimizer.h
+++ b/llvm/include/llvm/Cheerp/TypeOptimizer.h
@@ -120,7 +120,6 @@ private:
 
 	llvm::Module* module;
 	const llvm::DataLayout* DL;
-	std::unordered_set<const llvm::Type*> uncollapsibleSecondaryBases;
 	std::unordered_map<const llvm::StructType*,std::set<llvm::StructType*>> downcastSourceToDestinationsMapping;
 	std::unordered_map<const llvm::StructType*, std::vector<std::pair<uint32_t, uint32_t>>> membersMappingData;
 	std::unordered_map<llvm::GlobalValue*, llvm::Constant*> globalsMapping;

--- a/llvm/lib/CheerpUtils/TypeOptimizer.cpp
+++ b/llvm/lib/CheerpUtils/TypeOptimizer.cpp
@@ -263,22 +263,6 @@ void TypeOptimizer::gatherAllTypesInfo(const Module& M)
 		uint32_t fieldIndex = cast<ConstantInt>(*std::prev(GEP->op_end()))->getZExtValue();
 		escapingFields.emplace(containerStructType, fieldIndex, TypeAndIndex::STRUCT_MEMBER);
 	}
-
-	// Mark classes that cannot be collapsed because they are used as a secondary base
-	for (const auto sTy : M.getIdentifiedStructTypes())
-	{
-		uint32_t firstBase;
-		uint32_t baseCount;
-		if (TypeSupport::getBasesInfo(M, sTy, firstBase, baseCount))
-		{
-			for (uint32_t i = firstBase; i< (firstBase + baseCount); i++)
-			{
-				if (!sTy->getElementType(i)->isStructTy())
-					continue;
-				uncollapsibleSecondaryBases.insert(sTy->getElementType(i));
-			}
-		}
-	}
 }
 
 /**
@@ -310,9 +294,6 @@ bool TypeOptimizer::canCollapseStruct(llvm::StructType* st, llvm::StructType* ne
 		assert(st->isLiteral());
 		return true;
 	}
-	// Secondary bases used inside a hierarchy where a downcast is performed on cannot safely be collapsed
-	if (uncollapsibleSecondaryBases.count(st))
-		return false;
 	// Stop if the element is just a int8, we may be dealing with an empty struct
 	// Empty structs are unsafe as the int8 inside is just a placeholder and will be replaced
 	// by a different type in a derived class

--- a/llvm/lib/CheerpWriter/Types.cpp
+++ b/llvm/lib/CheerpWriter/Types.cpp
@@ -422,8 +422,14 @@ uint32_t CheerpWriter::compileClassTypeRecursive(const std::string& baseName, St
 
 	for(uint32_t i=firstBase;i<(firstBase+localBaseCount);i++)
 	{
+		// If a base was collapsed, fill its index in the array with null.
+		// It won't be accessed but we need to keep the indexing consistent.
 		if(!currentType->getElementType(i)->isStructTy())
+		{
+			stream << "a[" << baseCount << "]=null;" << NewLine;
+			baseCount++;
 			continue;
+		}
 		SmallString<16> buf;
 		llvm::raw_svector_ostream bufStream(buf);
 		bufStream << ".a" << i;


### PR DESCRIPTION
The real issue was that a collapsed struct used as a secondary base would leave a gap in the downcast array, shifting all following bases' indices by 1.
Instead of preventing a collapse of such structs, we instead fill the array slot with null.
This is ok because the slot is not accessed (if it was, the struct would not have collapsed). We just need to keep the indexing consistent.