### PR TITLE
libcxx: fix a subtle string bug caused by not doing small string optimization

### DIFF
--- a/libcxx/src/string.cpp
+++ b/libcxx/src/string.cpp
@@ -322,7 +322,7 @@ struct initial_string;
 template <>
 struct initial_string<string> {
     string operator()() const {
-        string s;
+        string s(20, char());
         s.resize(s.capacity());
         return s;
     }


### PR DESCRIPTION

the implementation of to_string() passes the address of the first element of a default-initialized string to snprintf. Normally, this is always a valid address because of the sso, but in Cheerp we don't do it so the size is 0 and the address is invalid. As a fix we initialize the string with an initial size > 0.