### PR TITLE
PreExecute: avoid overlap of function and value addresses

### DIFF
--- a/llvm/include/llvm/ExecutionEngine/FunctionMap.h
+++ b/llvm/include/llvm/ExecutionEngine/FunctionMap.h
@@ -43,7 +43,8 @@ public:
 private:
 	std::map<llvm::Function*, uint32_t> map;
 	std::map<uint32_t, llvm::Function*> rev_map;
-	uint32_t next_addr = 1;
+	// start from 1MB to make clashes with integers less likely
+	uint32_t next_addr = 1024*1024;
 
 };
 class DirectFunctionMap: public FunctionMapBase {

--- a/llvm/include/llvm/ExecutionEngine/VirtualAddressMap.h
+++ b/llvm/include/llvm/ExecutionEngine/VirtualAddressMap.h
@@ -64,10 +64,15 @@ public:
 		real_to_virt.erase(it);
 	}
 
-	VirtualAddressMap() {
+	VirtualAddressMap(uintptr_t num_functions) {
 		virt_to_real.emplace(0,Page(0,8));
 		real_to_virt.emplace(0,Page(0,8));
-		next_virt = 8;
+
+		constexpr uintptr_t MB = 1024*1024;
+		uintptr_t func_end = MB + num_functions;
+		// Align to the next MB, to ensure we are far away from the range of function
+		// addresses (which has a fixed start at 1MB)
+		next_virt = (func_end+MB-1) & ~(MB-1);
 	}
 private:
 	static std::map<uintptr_t, Page>::const_iterator find_start(const std::map<uintptr_t, Page>& mapping,  uintptr_t addr) {

--- a/llvm/lib/ExecutionEngine/Interpreter/Interpreter.cpp
+++ b/llvm/lib/ExecutionEngine/Interpreter/Interpreter.cpp
@@ -57,7 +57,7 @@ Interpreter::Interpreter(std::unique_ptr<Module> M, bool preExecute)
 
   if (preExecute) {
     ForPreExecute = true;
-    ValueAddresses = std::unique_ptr<AddressMapBase>(new VirtualAddressMap());
+    ValueAddresses = std::unique_ptr<AddressMapBase>(new VirtualAddressMap(Modules[0]->getFunctionList().size()));
     FunctionAddresses = std::unique_ptr<FunctionMapBase>(new VirtualFunctionMap());
   }
   memset(&ExitValue.Untyped, 0, sizeof(ExitValue.Untyped));


### PR DESCRIPTION
Both functions and values have virtual addresses, but they are in two different address spaces, which are overlapping.
But PreExecute is assuming that if a function is present at an address, the address represents that function, so we need disjunct address ranges.
For good measure we also start from 1MB for functions, to avoid potential clashes with small integers.
Values start the next MB-aligned address after all the functions.