### PR TITLE
Fix getting complete array type from extern variable redeclaration

### DIFF
--- a/clang/lib/CodeGen/CGExprConstant.cpp
+++ b/clang/lib/CodeGen/CGExprConstant.cpp
@@ -1997,9 +1997,14 @@ private:
       DestElemTy = CGM.getTypes().ConvertTypeForMem(DestType->getPointeeType());
     QualType CurType;
     const APValue::LValueBase &base = Value.getLValueBase();
-    if (const ValueDecl *D = base.dyn_cast<const ValueDecl*>())
+    if (const ValueDecl *D = base.dyn_cast<const ValueDecl*>()) {
+      if (const VarDecl *VD = dyn_cast<VarDecl>(D)) {
+        VD = VD->getInitializingDeclaration();
+        if (VD != nullptr)
+          D = VD;
+      }
       CurType = D->getType();
-    else if (const Expr *E = base.dyn_cast<const Expr*>())
+    } else if (const Expr *E = base.dyn_cast<const Expr*>())
       CurType = E->getType();
     else
       CurType = base.getTypeInfoType();


### PR DESCRIPTION
Turns out there's many many functions to get different parts of a declaration. After testing most if not all of them, I decided to go with `getInitializingDeclaration`. This most directly solves the crash in Alessandro's example, where it's trying to get type info from an array declaration with an incomplete array type.

I also looked into where exactly the declaration in the `APValue` comes from. I couldn't quite figure this out exactly, but I believe somewhere in a long chain of function calls, `getCanonicalDeclaration` is called, which returns the original incomplete extern declaration instead of the one with the initializer.