### PR TITLE
Change exit code catching and reporting

### DIFF
--- a/compiler-rt/test/asan/TestCases/atexit_stats.cpp
+++ b/compiler-rt/test/asan/TestCases/atexit_stats.cpp
@@ -1,6 +1,6 @@
 // Make sure we report atexit stats.
 // RUN: %clangxx_asan -O3 %s -o %t
-// RUN: not %run %t --cheerp-env=ASAN_OPTIONS=atexit=1:print_stats=1 2>&1 | FileCheck %s
+// RUN: %run %t --cheerp-env=ASAN_OPTIONS=atexit=1:print_stats=1 2>&1 | FileCheck %s
 //
 // No atexit output in older versions of Android due to
 // https://code.google.com/p/address-sanitizer/issues/detail?id=263

--- a/compiler-rt/test/asan/TestCases/use-after-scope-goto.cpp
+++ b/compiler-rt/test/asan/TestCases/use-after-scope-goto.cpp
@@ -3,8 +3,6 @@
 // Function jumps over variable initialization making lifetime analysis
 // ambiguous. Asan should ignore such variable and program must not fail.
 
-// XFAIL: cheerp
-
 #include <stdlib.h>
 
 int *ptr;

--- a/llvm/lib/CheerpWriter/CheerpWriter.cpp
+++ b/llvm/lib/CheerpWriter/CheerpWriter.cpp
@@ -6093,7 +6093,8 @@ void CheerpWriter::compileHandleVAArg()
 void CheerpWriter::compileCheerpException()
 {
 	stream << "function CheerpException(m,e,c){" << NewLine;
-	stream << "var instance=new Error('Uncaught C++ exception: '+m);" << NewLine;
+	stream << "var t=e?'':'Uncaught C++ exception: ';" << NewLine;
+	stream << "var instance=new Error(t+m);" << NewLine;
 	stream << "instance.name='CheerpException';" << NewLine;
 	stream << "instance.isExit=e;" << NewLine;
 	stream << "instance.code=c;" << NewLine;
@@ -7141,13 +7142,7 @@ void CheerpWriter::compileEntryPoint()
 		if (LowerAtomics)
 		{
 			stream << "}catch(e){" << NewLine;
-			stream << "if(e instanceof CheerpException&&e.isExit){" << NewLine;
-			stream << "if(e.code != 0){" << NewLine;
-			stream << "console.log('Program failed. Exit code:', e.code);" << NewLine;
-			stream << "}" << NewLine;
-			stream << "}else{" << NewLine;
-			stream << "throw(e);" << NewLine;
-			stream << "}" << NewLine;
+			stream << "if(!(e instanceof CheerpException&&e.isExit&&e.code==0))throw(e);" << NewLine;
 			stream << "}" << NewLine;
 		}
 	}


### PR DESCRIPTION
When the exit exception is filtered and printed, the exit behaviour for node is changed, because there is no longer an uncaught exception. We now only catch the exception when it is non-zero, so an exit code of 0 will not report as an error. The message, instead of being printed in the console, is now in the exception itself.