### PR TITLE
Implement get_thread_pointer in PreExecuter

### DIFF
--- a/llvm/lib/ExecutionEngine/Interpreter/Execution.cpp
+++ b/llvm/lib/ExecutionEngine/Interpreter/Execution.cpp
@@ -1184,6 +1184,15 @@ void Interpreter::visitIntrinsicInst(IntrinsicInst &I) {
 
   if (ForPreExecute && strncmp(I.getCalledFunction()->getName().str().c_str(), "llvm.cheerp", strlen("llvm.cheerp")) == 0)
   {
+    if (I.getCalledFunction()->getName() == "llvm.cheerp.get.thread.pointer")
+    {
+      // We return a value of zero. The code in musl will instead assign it the address of the __dummy_thread variable.
+      IntegerType* Ty = cast<IntegerType>(I.getType());
+      GenericValue Result;
+      Result.IntVal = APInt(Ty->getBitWidth(), 0);
+      SetValue(&I, Result, SF);
+      return;
+    }
     errs() << "Tried to execute cheerp intrinsic: " << I.getCalledFunction()->getName() << "\n";
     printCallTrace();
     CleanAbort = true;


### PR DESCRIPTION
The PreExecuter would fail when trying to execute the intrinsic llvm.cheerp.get.thread.pointer. And since this would occur in the global constructor with priority 101, no other global constructors would run. This commit introduces a simple fix: we return 0. The code that actually calls this intrinsic in musl then will use __dummy_thread as the thread pointer.