### PR TITLE
now compiles properly with everything defined

### DIFF
--- a/llvm/include/llvm/ADT/SmallVector.h
+++ b/llvm/include/llvm/ADT/SmallVector.h
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <functional>

--- a/llvm/include/llvm/Cheerp/Demangler.h
+++ b/llvm/include/llvm/Cheerp/Demangler.h
@@ -14,6 +14,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 #include <cstring>
 #include <cassert>
 #include <cstdint>

--- a/llvm/include/llvm/Support/Threading.h
+++ b/llvm/include/llvm/Support/Threading.h
@@ -18,7 +18,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Config/llvm-config.h" // for LLVM_ON_UNIX
 #include "llvm/Support/Compiler.h"
-#include <ciso646> // So we can check the C++ standard lib macros.
+#include <version> // So we can check the C++ standard lib macros.
 
 #if defined(_MSC_VER)
 // MSVC's call_once implementation worked since VS 2015, which is the minimum

--- a/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h
+++ b/llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h
@@ -15,6 +15,7 @@
 
 #include <memory>
 #include <string>
+#include <cstdint>
 
 namespace llvm {
 class formatted_raw_ostream;

--- a/llvm/lib/Transforms/Scalar/GVNSink.cpp
+++ b/llvm/lib/Transforms/Scalar/GVNSink.cpp
@@ -242,7 +242,7 @@ public:
     SmallVector<std::pair<int, std::pair<BasicBlock *, Value *>>, 4> Ops;
     for (unsigned I = 0, E = PN->getNumIncomingValues(); I != E; ++I) {
       BasicBlock* incomingBlock = PN->getIncomingBlock(I);
-      Ops.push_back({BasicBlockOrder->operator[](incomingBlock), {incomingBlock, PN->getIncomingValue(I)}});
+      Ops.push_back({static_cast<int>(BasicBlockOrder->operator[](incomingBlock)), {incomingBlock, PN->getIncomingValue(I)}});
     }
 
     llvm::sort(Ops);


### PR DESCRIPTION
There were some issues with newer versions of some system C++ headers do not longer contain int type definitions in them. Also for C++17 <ciso646> is deprecated and <version> should be used. Also an explicit cast to int in llvm/lib/Transforms/Scalar/GVNSink.cpp so no error