### PR TITLE
Remove getPointerElementType calls part 2

### DIFF
--- a/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/clang/lib/CodeGen/CGExprScalar.cpp
@@ -2246,7 +2246,8 @@ Value *ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
     // space, an address space conversion may end up as a bitcast.
     return CGF.CGM.getTargetCodeGenInfo().performAddrSpaceCast(
         CGF, Visit(E), E->getType()->getPointeeType().getAddressSpace(),
-        DestTy->getPointeeType().getAddressSpace(), ConvertType(DestTy));
+        DestTy->getPointeeType().getAddressSpace(), ConvertType(DestTy),
+        false, ConvertType(DestTy->getPointeeType()));
   }
   case CK_AtomicToNonAtomic:
   case CK_NonAtomicToAtomic:

--- a/clang/lib/CodeGen/TargetInfo.h
+++ b/clang/lib/CodeGen/TargetInfo.h
@@ -290,7 +290,8 @@ public:
   virtual llvm::Value *performAddrSpaceCast(CodeGen::CodeGenFunction &CGF,
                                             llvm::Value *V, LangAS SrcAddr,
                                             LangAS DestAddr, llvm::Type *DestTy,
-                                            bool IsNonNull = false) const;
+                                            bool IsNonNull = false,
+                                            llvm::Type* ElemTy = nullptr) const;
 
   /// Perform address space cast of a constant expression of pointer type.
   /// \param V is the LLVM constant to be casted to another address space.

--- a/llvm/include/llvm/Cheerp/Utility.h
+++ b/llvm/include/llvm/Cheerp/Utility.h
@@ -262,6 +262,7 @@ inline bool isBitCast(const llvm::Value* v)
 		{
 			case llvm::Intrinsic::cheerp_cast_user:
 			case llvm::Intrinsic::cheerp_upcast_collapsed:
+			case llvm::Intrinsic::cheerp_typed_ptrcast:
 				return true;
 			default:
 				break;

--- a/llvm/include/llvm/Cheerp/Utility.h
+++ b/llvm/include/llvm/Cheerp/Utility.h
@@ -102,6 +102,8 @@ const static int V8MaxLiteralProperties = 8;
 bool isNopCast(const llvm::Value* val);
 bool isValidVoidPtrSource(const llvm::Value* val, std::set<const llvm::PHINode*>& visitedPhis);
 
+const llvm::IntToPtrInst* getAsIntToPtrInst(const llvm::Value* val);
+
 inline void assertPointerElementOrOpaque(llvm::Type* pointer, llvm::Type* pointee)
 {
 	assert(llvm::isa<llvm::PointerType>(pointer));

--- a/llvm/include/llvm/Cheerp/Writer.h
+++ b/llvm/include/llvm/Cheerp/Writer.h
@@ -372,7 +372,7 @@ private:
 	/**
 	 * Compile the pointer base.
 	 */
-	void compilePointerBase(const llvm::Value*, bool forEscapingPointer=false);
+	void compilePointerBase(const llvm::Value*, bool forEscapingPointer=false, bool useGPET=false);
 	void compilePointerBaseTyped(const llvm::Value*, llvm::Type* elementType, bool forEscapingPointer=false);
 
 	/**

--- a/llvm/include/llvm/IR/IntrinsicsCheerp.td
+++ b/llvm/include/llvm/IR/IntrinsicsCheerp.td
@@ -37,6 +37,11 @@ def int_cheerp_cast_user  : Intrinsic<[llvm_anyptr_ty],
                              [llvm_anyptr_ty],
                              []>;
 
+def int_cheerp_typed_ptrcast : Intrinsic<[llvm_anyptr_ty],
+                                      [llvm_anyptr_ty],
+                                      [IntrNoMem]>;
+
+
 // Type safe memory allocation
 def int_cheerp_allocate  : Intrinsic<[llvm_anyptr_ty],
                              [llvm_ptr_ty,llvm_i32_ty]>;

--- a/llvm/lib/CheerpUtils/PointerAnalyzer.cpp
+++ b/llvm/lib/CheerpUtils/PointerAnalyzer.cpp
@@ -642,6 +642,7 @@ PointerKindWrapper& PointerUsageVisitor::visitValue(PointerKindWrapper& ret, con
 		case Intrinsic::cheerp_downcast:
 		case Intrinsic::cheerp_upcast_collapsed:
 		case Intrinsic::cheerp_cast_user:
+		case Intrinsic::cheerp_typed_ptrcast:
 			break;
 		case Intrinsic::cheerp_allocate:
 		case Intrinsic::cheerp_allocate_array:
@@ -891,6 +892,8 @@ PointerKindWrapper& PointerUsageVisitor::visitUse(PointerKindWrapper& ret, const
 			return visitValue( ret, p, /*first*/ false );
 		case Intrinsic::cheerp_virtualcast:
 			return ret |= COMPLETE_OBJECT;
+		case Intrinsic::cheerp_typed_ptrcast:
+			return ret |= PointerKindWrapper(SPLIT_REGULAR, p);
 		case Intrinsic::cheerp_downcast:
 		{
 			// Behaves like a cast if the offset is constant 0

--- a/llvm/lib/CheerpUtils/PointerAnalyzer.cpp
+++ b/llvm/lib/CheerpUtils/PointerAnalyzer.cpp
@@ -643,6 +643,8 @@ PointerKindWrapper& PointerUsageVisitor::visitValue(PointerKindWrapper& ret, con
 		case Intrinsic::cheerp_upcast_collapsed:
 		case Intrinsic::cheerp_cast_user:
 		case Intrinsic::cheerp_typed_ptrcast:
+			if (isa<IntToPtrInst>(intrinsic->getArgOperand(0)))
+				return CacheAndReturn(visitValue(ret, intrinsic->getArgOperand(0), false));
 			break;
 		case Intrinsic::cheerp_allocate:
 		case Intrinsic::cheerp_allocate_array:
@@ -855,7 +857,7 @@ PointerKindWrapper& PointerUsageVisitor::visitUse(PointerKindWrapper& ret, const
 		if ( !I->isEquality() )
 			return ret |= PointerKindWrapper(SPLIT_REGULAR, p);
 		Value* Other = I->getOperand(0) == U->get() ? I->getOperand(1) : I->getOperand(0);
-		if ( visitRawChain(Other) || isa<IntToPtrInst>(Other))
+		if ( visitRawChain(Other) || getAsIntToPtrInst(Other))
 			return ret |= PointerKindWrapper(SPLIT_REGULAR, p);
 		else
 			return ret |= COMPLETE_OBJECT;

--- a/llvm/lib/CheerpUtils/TypeOptimizer.cpp
+++ b/llvm/lib/CheerpUtils/TypeOptimizer.cpp
@@ -1107,6 +1107,7 @@ Function* TypeOptimizer::rewriteIntrinsic(Function* F, FunctionType* FT)
 		}
 		case Intrinsic::cheerp_upcast_collapsed:
 		case Intrinsic::cheerp_cast_user:
+		case Intrinsic::cheerp_typed_ptrcast:
 		case Intrinsic::cheerp_downcast:
 		case Intrinsic::cheerp_virtualcast:
 		case Intrinsic::cheerp_make_complete_object:

--- a/llvm/lib/CheerpUtils/Utility.cpp
+++ b/llvm/lib/CheerpUtils/Utility.cpp
@@ -84,6 +84,16 @@ bool isValidVoidPtrSource(const Value* val, std::set<const PHINode*>& visitedPhi
 	return false;
 }
 
+const llvm::IntToPtrInst* getAsIntToPtrInst(const llvm::Value* val)
+{
+	if (const llvm::IntrinsicInst* intrinsic = llvm::dyn_cast<llvm::IntrinsicInst>(val))
+		if (intrinsic->getIntrinsicID() == llvm::Intrinsic::cheerp_typed_ptrcast)
+			val = intrinsic->getArgOperand(0);
+	if (const llvm::IntToPtrInst* inttoptr = llvm::dyn_cast<llvm::IntToPtrInst>(val))
+		return inttoptr;
+	return nullptr;
+}
+
 int32_t partialOffset(llvm::Type* & curType, llvm::Type* alternative, const llvm::DataLayout& DL, const int32_t index)
 {
 	int32_t partialOffset = 0;

--- a/llvm/lib/CheerpUtils/Utility.cpp
+++ b/llvm/lib/CheerpUtils/Utility.cpp
@@ -331,6 +331,7 @@ bool InlineableCache::isInlineableImpl(const Instruction& I)
 		switch(II->getIntrinsicID())
 		{
 			case Intrinsic::cheerp_cast_user:
+			case Intrinsic::cheerp_typed_ptrcast:
 			case Intrinsic::cheerp_upcast_collapsed:
 			case Intrinsic::cheerp_make_regular:
 				return true;

--- a/llvm/lib/CheerpWriter/CheerpWriter.cpp
+++ b/llvm/lib/CheerpWriter/CheerpWriter.cpp
@@ -873,6 +873,14 @@ CheerpWriter::COMPILE_INSTRUCTION_FEEDBACK CheerpWriter::handleBuiltinCall(const
 		compileBitCast(&callV, PA.getPointerKindAssert(&callV), HIGHEST);
 		return COMPILE_OK;
 	}
+	else if(intrinsicId==Intrinsic::cheerp_typed_ptrcast)
+	{
+		if(callV.use_empty())
+			return COMPILE_EMPTY;
+
+		compileBitCast(&callV, PA.getPointerKindAssert(&callV), HIGHEST);
+		return COMPILE_OK;
+	}
 	else if(intrinsicId==Intrinsic::cheerp_pointer_base)
 	{
 		compilePointerBase(*it, true);
@@ -2008,6 +2016,7 @@ void CheerpWriter::compilePointerBaseTyped(const Value* p, Type* elementType, bo
 		switch(II->getIntrinsicID())
 		{
 			case Intrinsic::cheerp_upcast_collapsed:
+			case Intrinsic::cheerp_typed_ptrcast:
 			case Intrinsic::cheerp_cast_user:
 				return compilePointerBaseTyped(II->getOperand(0), II->getParamElementType(0));
 			case Intrinsic::cheerp_make_regular:
@@ -2213,6 +2222,7 @@ void CheerpWriter::compilePointerOffset(const Value* p, PARENT_PRIORITY parentPr
 		switch(II->getIntrinsicID())
 		{
 			case Intrinsic::cheerp_upcast_collapsed:
+			case Intrinsic::cheerp_typed_ptrcast:
 			case Intrinsic::cheerp_cast_user:
 				compilePointerOffset(II->getOperand(0), parentPrio);
 				return;
@@ -4575,7 +4585,7 @@ void CheerpWriter::compileLoadElem(const LoadInst& li, Type* Ty, StructType* STy
 		assert(!STy);
 		//Optimize loads of single values from unions
 		compilePointerBase(ptrOp);
-		assert(ptrOp->getType()== Ty->getPointerTo());
+		assert(ptrOp->getType()== Ty->getPointerTo(ptrOp->getType()->getPointerAddressSpace()));
 		if(Ty->isIntegerTy(8))
 			stream << ".getUint8(";
 		else if(Ty->isIntegerTy(16))

--- a/llvm/lib/CheerpWriter/CheerpWriter.cpp
+++ b/llvm/lib/CheerpWriter/CheerpWriter.cpp
@@ -1622,9 +1622,9 @@ void CheerpWriter::compileEqualPointersComparison(const llvm::Value* lhs, const 
 				isInlineable(*cast<Instruction>(lhs), PA));
 		assert(rhsKind != COMPLETE_OBJECT || !isa<Instruction>(rhs) ||
 				isInlineable(*cast<Instruction>(rhs), PA));
-		compilePointerBase(lhs);
+		compilePointerBase(lhs, false, true);
 		stream << compareString;
-		compilePointerBase(rhs);
+		compilePointerBase(rhs, false, true);
 		stream << joinString;
 		compilePointerOffset(lhs, COMPARISON);
 		stream << compareString;
@@ -1634,9 +1634,9 @@ void CheerpWriter::compileEqualPointersComparison(const llvm::Value* lhs, const 
 	{
 		assert(lhsKind != COMPLETE_OBJECT);
 		assert(rhsKind != COMPLETE_OBJECT);
-		compilePointerBase(lhs);
+		compilePointerBase(lhs, false, true);
 		stream << compareString;
-		compilePointerBase(rhs);
+		compilePointerBase(rhs, false, true);
 		stream << joinString;
 		compilePointerOffset(lhs, COMPARISON);
 		stream << compareString;
@@ -1731,6 +1731,7 @@ void CheerpWriter::compileCompleteObject(const Value* p, const Value* offset)
 		}
 		return;
 	}
+
 
 	const llvm::Instruction* I = dyn_cast<Instruction>(p);
 	if (I && !isInlineable(*I, PA) &&
@@ -1960,9 +1961,32 @@ void CheerpWriter::compileHeapAccess(const Value* p, Type* t, uint32_t offset)
 		stream << pointerShiftOperator() << shift;
 	stream << ']';
 }
-void CheerpWriter::compilePointerBase(const Value* p, bool forEscapingPointer)
+void CheerpWriter::compilePointerBase(const Value* p, bool forEscapingPointer, bool useGPET)
 {
-	compilePointerBaseTyped(p, p->getType()->getPointerElementType(), forEscapingPointer);
+	if(const IntrinsicInst* II=dyn_cast<IntrinsicInst>(p))
+	{
+		switch(II->getIntrinsicID())
+		{
+			case Intrinsic::cheerp_upcast_collapsed:
+			case Intrinsic::cheerp_typed_ptrcast:
+			case Intrinsic::cheerp_cast_user:
+				return compilePointerBaseTyped(II->getOperand(0), II->getParamElementType(0), forEscapingPointer);
+			default:
+				break;
+		}
+	}
+
+	POINTER_KIND kind = PA.getPointerKind(p);
+
+	if (kind != RAW && (kind != CONSTANT || isa<ConstantPointerNull>(p)))
+	{
+		// point element type is not used in this case, so it can be null
+		compilePointerBaseTyped(p, nullptr, forEscapingPointer);
+	}
+	else if (useGPET || isa<BitCastInst>(p) || isa<UndefValue>(p))
+		compilePointerBaseTyped(p, p->getType()->getPointerElementType(), forEscapingPointer);
+	else
+		llvm::report_fatal_error("Missing typed ptrcast intrinsic and no GPET allowed");
 }
 
 void CheerpWriter::compilePointerBaseTyped(const Value* p, Type* elementType, bool forEscapingPointer)
@@ -2018,6 +2042,7 @@ void CheerpWriter::compilePointerBaseTyped(const Value* p, Type* elementType, bo
 			case Intrinsic::cheerp_upcast_collapsed:
 			case Intrinsic::cheerp_typed_ptrcast:
 			case Intrinsic::cheerp_cast_user:
+				assert(elementType == II->getParamElementType(0));
 				return compilePointerBaseTyped(II->getOperand(0), II->getParamElementType(0));
 			case Intrinsic::cheerp_make_regular:
 				return compileCompleteObject(II->getOperand(0));
@@ -2171,7 +2196,7 @@ void CheerpWriter::compilePointerOffset(const Value* p, PARENT_PRIORITY parentPr
 	// null must be handled first, even if it is bytelayout
 	else if(kind == CONSTANT || isa<UndefValue>(p))
 	{
-		if (const IntToPtrInst* ITP = dyn_cast<IntToPtrInst>(p))
+		if (const IntToPtrInst* ITP = getAsIntToPtrInst(p))
 		{
 			ConstantInt* CI = cast<ConstantInt>(ITP->getOperand(0));
 			stream << CI->getSExtValue();
@@ -3034,10 +3059,10 @@ void CheerpWriter::compileMethodArgs(User::const_op_iterator it, User::const_op_
 				(argKind == COMPLETE_OBJECT && curKind == BYTE_LAYOUT))
 			{
 				if(F && PA.getConstantOffsetForPointer(&*arg_it))
-					compilePointerBase(*cur, true);
+					compilePointerBase(*cur, true, true);
 				else
 				{
-					compilePointerBase(*cur, true);
+					compilePointerBase(*cur, true, true);
 					stream << ',';
 					compilePointerOffset(*cur, LOWEST, true);
 				}

--- a/llvm/lib/CheerpWriter/PreExecute.cpp
+++ b/llvm/lib/CheerpWriter/PreExecute.cpp
@@ -490,6 +490,10 @@ static GenericValue pre_execute_upcast(FunctionType *FT,
     return Args[0]; 
 }
 
+static GenericValue pre_execute_typed_ptrcast(FunctionType* FT, ArrayRef<GenericValue> Args, AttributeList Attrs) {
+    return Args[0];
+}
+
 static GenericValue assertEqualImpl(FunctionType *FT,
         ArrayRef<GenericValue> Args, AttributeList Attrs)
 {
@@ -524,6 +528,8 @@ static void* LazyFunctionCreator(const std::string& funcName)
         return (void*)(void(*)())pre_execute_virtualcast;
     if (strncmp(funcName.c_str(), "llvm.cheerp.upcast.", strlen("llvm.cheerp.upcast."))==0)
         return (void*)(void(*)())pre_execute_upcast;
+    if (strncmp(funcName.c_str(), "llvm.cheerp.typed.ptrcast.", strlen("llvm.cheerp.typed.ptrcast."))==0)
+        return (void*)(void(*)())pre_execute_typed_ptrcast;
     if (strncmp(funcName.c_str(), "llvm.cheerp.allocate.array.", strlen("llvm.cheerp.allocate.array."))==0)
         return (void*)(void(*)())pre_execute_allocate_array;
     if (strncmp(funcName.c_str(), "llvm.cheerp.allocate.", strlen("llvm.cheerp.allocate."))==0)


### PR DESCRIPTION
No getPointerElementType calls are actually removed in the current changes. This is just support work that is needed for them to be removed later.