### PR TITLE
Writer: add missing GlobalVariable case to getRawType

### DIFF
--- a/llvm/lib/CheerpWriter/CheerpWriter.cpp
+++ b/llvm/lib/CheerpWriter/CheerpWriter.cpp
@@ -1995,6 +1995,10 @@ static Type* getRawType(const Value* p)
 	{
 		return GEPI->getResultElementType();
 	}
+	else if (const GlobalVariable* G = dyn_cast<GlobalVariable>(p))
+	{
+		return G->getValueType();
+	}
 
 	return nullptr;
 }


### PR DESCRIPTION
When compiling CheerpX, I get:

```
@heapData = internal global i8 0, section "asmjs", align 4
LLVM ERROR: Missing typed ptrcast intrinsic and no GPET allowed
```

This commit seems to fix the issue