### PR TITLE
Add -cheerp-print-ir option

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -4958,6 +4958,8 @@ def cheerp_sourcemap_standalone : Flag<["-"], "cheerp-sourcemap-standalone">, Fl
   HelpText<"Generate a standalone sourcemap by including _all_ sources in the map file">;
 def cheerp_pretty_code : Flag<["-"], "cheerp-pretty-code">, Flags<[NoXarchOption]>,
   HelpText<"Generate human-readable JS">;
+def cheerp_print_ir : Flag<["-"], "cheerp-print-ir">, Flags<[NoXarchOption]>,
+  HelpText<"Print commented LLVM-IR alongside JS output">;
 def cheerp_asmjs_symbolic_globals : Flag<["-"], "cheerp-asmjs-symbolic-globals">, Flags<[NoXarchOption]>,
   HelpText<"Compile global variable addresses as js variables in the asm.js module">;
 def cheerp_make_module : Flag<["-"], "cheerp-make-module">, Flags<[NoXarchOption]>,

--- a/clang/lib/Driver/ToolChains/WebAssembly.cpp
+++ b/clang/lib/Driver/ToolChains/WebAssembly.cpp
@@ -1080,6 +1080,8 @@ void cheerp::CheerpCompiler::ConstructJob(Compilation &C, const JobAction &JA,
     cheerpSourceMapStandAlone->render(Args, CmdArgs);
   if(Arg* cheerpPrettyCode = Args.getLastArg(options::OPT_cheerp_pretty_code))
     cheerpPrettyCode->render(Args, CmdArgs);
+  if(Arg* cheerpPrintIR = Args.getLastArg(options::OPT_cheerp_print_ir))
+    cheerpPrintIR->render(Args, CmdArgs);
   if(Arg* cheerpAsmJSSymbolicGlobals = Args.getLastArg(options::OPT_cheerp_asmjs_symbolic_globals))
     cheerpAsmJSSymbolicGlobals->render(Args, CmdArgs);
   if(Arg* cheerpNoNativeMath = Args.getLastArg(options::OPT_cheerp_no_native_math))

--- a/llvm/include/llvm/Cheerp/CommandLine.h
+++ b/llvm/include/llvm/Cheerp/CommandLine.h
@@ -29,6 +29,7 @@ extern llvm::cl::opt<bool> MakeDTS;
 extern llvm::cl::opt<bool> WasmOnly;
 extern llvm::cl::opt<bool> SourceMapStandAlone;
 extern llvm::cl::opt<bool> PrettyCode;
+extern llvm::cl::opt<bool> PrintIR;
 extern llvm::cl::opt<bool> SymbolicGlobalsAsmJS;
 extern llvm::cl::opt<bool> NoNativeJavaScriptMath;
 extern llvm::cl::opt<bool> NoJavaScriptMathImul;

--- a/llvm/include/llvm/Cheerp/Writer.h
+++ b/llvm/include/llvm/Cheerp/Writer.h
@@ -289,6 +289,8 @@ private:
 	bool symbolicGlobalsAsmJS;
 	// Flag to signal if we should emit readable or compressed output
 	bool readableOutput;
+	// Flag to signal if we should print commented llvm-ir alongside js output.
+	bool printIR;
 	// Flag to keep track of state of already declared stuff
 	bool areDummiesDeclared{false};
 	bool areAsmJSExportsDeclared{false};
@@ -653,7 +655,8 @@ public:
 			bool checkBounds,
 			bool compileGlobalsAddrAsmJS,
 			const std::string& wasmFile,
-			bool forceTypedArrays):
+			bool forceTypedArrays,
+			bool printIR):
 		module(m),
 		MAM(MAM),
 		FAM(MAM.getResult<llvm::FunctionAnalysisManagerModuleProxy>(m).getManager()),
@@ -689,7 +692,8 @@ public:
 		readableOutput(readableOutput),
 		blockDepth(0),
 		lastDepth0Block(nullptr),
-		stream(s, sourceMapGenerator, readableOutput)
+		stream(s, sourceMapGenerator, readableOutput),
+		printIR(printIR)
 	{
 	}
 	void makeJS();

--- a/llvm/lib/CheerpUtils/CommandLine.cpp
+++ b/llvm/lib/CheerpUtils/CommandLine.cpp
@@ -30,6 +30,8 @@ llvm::cl::opt<bool> SourceMapStandAlone("cheerp-sourcemap-standalone", llvm::cl:
 
 llvm::cl::opt<bool> PrettyCode("cheerp-pretty-code", llvm::cl::desc("Generate human-readable JS") );
 
+llvm::cl::opt<bool> PrintIR("cheerp-print-ir", llvm::cl::desc("Print commented LLVM-IR alongside JS output") );
+
 llvm::cl::opt<bool> SymbolicGlobalsAsmJS("cheerp-asmjs-symbolic-globals", llvm::cl::desc("Compile global variables addresses as js variables in the asm.js module") );
 
 llvm::cl::opt<bool> NoNativeJavaScriptMath("cheerp-no-native-math", llvm::cl::desc("Disable native JavaScript math functions") );

--- a/llvm/lib/CheerpWriter/CheerpWriter.cpp
+++ b/llvm/lib/CheerpWriter/CheerpWriter.cpp
@@ -5347,6 +5347,13 @@ void CheerpWriter::compileBB(const BasicBlock& BB)
 	}
 	for(const auto& I: BB)
 	{
+		if (printIR)
+		{
+			stream << "/*";
+			I.print(stream.getRawStream());
+			stream << "*/" << NewLine;
+		}
+
 		if(const PHINode* phi = dyn_cast<PHINode>(&I))
 		{
 			continue;

--- a/llvm/lib/Target/WebAssembly/CheerpWritePass.cpp
+++ b/llvm/lib/Target/WebAssembly/CheerpWritePass.cpp
@@ -122,7 +122,7 @@ PreservedAnalyses cheerp::CheerpWritePassImpl::run(Module& M, ModuleAnalysisMana
     cheerp::CheerpWriter writer(M, MAM, Out, PA, registerize, GDA, linearHelper, namegen, allocaStoresExtractor, IW.getLandingPadTable(), memOut, asmjsMemFile,
                                 sourceMapGenerator.get(), PrettyCode, makeModule, !NoNativeJavaScriptMath,
                                 !NoJavaScriptMathImul, !NoJavaScriptMathFround, !NoCredits, MeasureTimeToMain, CheerpHeapSize,
-                                BoundsCheck, SymbolicGlobalsAsmJS, wasmFile, ForceTypedArrays);
+                                BoundsCheck, SymbolicGlobalsAsmJS, wasmFile, ForceTypedArrays, PrintIR);
     writer.makeJS();
   }
 


### PR DESCRIPTION
I considered a few different ways of printing inlineable instructions, but printing anything on the same line as javascript code just makes the javascript very hard to parse. In the end I found just printing everything top to bottom is the most readable.