### PR TITLE
as/codegen first batch

### DIFF
--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -2816,6 +2816,9 @@ public:
 
   LangAS getLangASForBuiltinAddressSpace(unsigned AS) const;
 
+  LangAS getCheerpTypeAddressSpace(QualType Ty, LangAS fallback = LangAS::Default) const;
+  LangAS getCheerpTypeAddressSpace(const Decl* D, LangAS fallback = LangAS::Default) const;
+
   /// Get target-dependent integer value for null pointer which is used for
   /// constant folding.
   uint64_t getTargetNullPointerValue(QualType QT) const;

--- a/clang/lib/Basic/Targets/WebAssembly.h
+++ b/clang/lib/Basic/Targets/WebAssembly.h
@@ -17,6 +17,7 @@
 #include "clang/Basic/TargetOptions.h"
 #include "llvm/ADT/Triple.h"
 #include "llvm/Support/Compiler.h"
+#include "llvm/Cheerp/AddressSpaces.h"
 
 namespace clang {
 namespace targets {
@@ -209,10 +210,10 @@ static const unsigned CheerpAddrSpaceMap[] = {
     0, // ptr32_uptr
     0, // ptr64
     0,   // hlsl_groupshared
-    0,  // cheerp_client
-    0,  // cheerp_genericjs
-    0,  // cheerp_bl
-    0,  // cheerp_wasm
+    (unsigned)cheerp::CheerpAS::Client,  // cheerp_client
+    (unsigned)cheerp::CheerpAS::GenericJS,  // cheerp_genericjs
+    (unsigned)cheerp::CheerpAS::ByteLayout,  // cheerp_bl
+    (unsigned)cheerp::CheerpAS::Wasm,  // cheerp_wasm
 };
 
 // Cheerp base class

--- a/llvm/include/llvm/Cheerp/AddressSpaces.h
+++ b/llvm/include/llvm/Cheerp/AddressSpaces.h
@@ -1,0 +1,27 @@
+//===-- Cheerp/AddressSpaces.h - Cheerp-specific address spaces -----------===//
+//
+//                     Cheerp: The C++ compiler for the Web
+//
+// This file is distributed under the Apache License v2.0 with LLVM Exceptions.
+// See LICENSE.TXT for details.
+//
+// Copyright 2011-2025 Leaning Technologies
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CHEERP_ADDRESS_SPACES_H
+#define _CHEERP_ADDRESS_SPACES_H
+
+namespace cheerp {
+
+enum class CheerpAS {
+	Default = 0,
+	Client = 1,
+	GenericJS = 2,
+	ByteLayout = 3,
+	Wasm = 4,
+};
+
+} // namespace cheerp
+
+#endif // _CHEERP_ADDRESS_SPACES_H

--- a/llvm/include/llvm/Cheerp/AddressSpaces.h
+++ b/llvm/include/llvm/Cheerp/AddressSpaces.h
@@ -22,6 +22,22 @@ enum class CheerpAS {
 	Wasm = 4,
 };
 
+inline CheerpAS getCheerpFunctionAS(CheerpAS AS) {
+	switch (AS) {
+	case CheerpAS::Default:
+		return AS;
+	case CheerpAS::GenericJS:
+		return CheerpAS::Client;
+	case CheerpAS::Wasm:
+		return AS;
+	default:
+		assert(false);
+	}
+}
+inline unsigned getCheerpFunctionAS(unsigned AS) {
+	return static_cast<unsigned>(getCheerpFunctionAS(static_cast<CheerpAS>(AS)));
+}
+
 } // namespace cheerp
 
 #endif // _CHEERP_ADDRESS_SPACES_H

--- a/llvm/include/llvm/Cheerp/Utility.h
+++ b/llvm/include/llvm/Cheerp/Utility.h
@@ -34,6 +34,7 @@
 #include "llvm/Cheerp/CommandLine.h"
 #include "llvm/Cheerp/DeterministicUnorderedSet.h"
 #include "llvm/Cheerp/ForbiddenIdentifiers.h"
+#include "llvm/Cheerp/AddressSpaces.h"
 
 namespace cheerp
 {

--- a/llvm/lib/CheerpUtils/CallConstructors.cpp
+++ b/llvm/lib/CheerpUtils/CallConstructors.cpp
@@ -98,8 +98,9 @@ PreservedAnalyses CallConstructorsPass::run(llvm::Module &M, llvm::ModuleAnalysi
 			Function* GetArgs = M.getFunction("__syscall_main_args");
 			if (GetArgs && GetArgs->getSection() == Main->getSection())
 			{
-				Value* ArgcA = Builder.CreateAlloca(ArgcTy);
-				Value* ArgvA = Builder.CreateAlloca(ArgvTy);
+				unsigned AS = GetArgs->getFunctionType()->getParamType(0)->getPointerAddressSpace();
+				Value* ArgcA = Builder.CreateAlloca(ArgcTy, AS);
+				Value* ArgvA = Builder.CreateAlloca(ArgvTy, AS);
 				ArrayRef<Value*> ArgsA = { ArgcA, ArgvA };
 				Builder.CreateCall(GetArgs->getFunctionType(), GetArgs, { ArgcA, ArgvA});
 				Argc = Builder.CreateLoad(ArgcTy, ArgcA);

--- a/llvm/lib/CheerpUtils/CallConstructors.cpp
+++ b/llvm/lib/CheerpUtils/CallConstructors.cpp
@@ -125,8 +125,9 @@ PreservedAnalyses CallConstructorsPass::run(llvm::Module &M, llvm::ModuleAnalysi
 				}
 				else
 				{
-					Env = Builder.CreateAlloca(Builder.getInt8Ty()->getPointerTo(0));
-					Builder.CreateStore(ConstantPointerNull::get(Builder.getInt8Ty()->getPointerTo(0)), Env);
+					unsigned AS = EnvTy->getPointerAddressSpace();
+					Env = Builder.CreateAlloca(Builder.getInt8Ty()->getPointerTo(AS));
+					Builder.CreateStore(ConstantPointerNull::get(Builder.getInt8Ty()->getPointerTo(AS)), Env);
 				}
 
 

--- a/llvm/lib/CheerpUtils/LowerGlobalDestructors.cpp
+++ b/llvm/lib/CheerpUtils/LowerGlobalDestructors.cpp
@@ -45,7 +45,7 @@ void LowerGlobalDestructorsPass::filterGenericJSDestructors(Module& M)
 			break;
 
 		elementType = O->getType();
-		Function* destructorFunc = dyn_cast<Function>(destructor);
+		Function* destructorFunc = dyn_cast<Function>(destructor->stripPointerCastsSafe());
 		assert(destructorFunc);
 		if (destructorFunc->getSection() == "asmjs")
 			validDestructors.push_back(cast<Constant>(O));

--- a/llvm/lib/CheerpWriter/CheerpWasmWriter.cpp
+++ b/llvm/lib/CheerpWriter/CheerpWasmWriter.cpp
@@ -1524,6 +1524,7 @@ void CheerpWasmWriter::compileConstantExpr(WasmBuffer& code, const ConstantExpr*
 			break;
 		}
 		case Instruction::BitCast:
+		case Instruction::AddrSpaceCast:
 		{
 			assert(ce->getOperand(0)->getType()->isPointerTy());
 			compileOperand(code, ce->getOperand(0));
@@ -2415,6 +2416,11 @@ bool CheerpWasmWriter::compileInlineInstruction(WasmBuffer& code, const Instruct
 				assert(operand->getType()->isIntegerTy(64));
 				encodeInst(WasmOpcode::F64_REINTERPRET_I64, code);
 			}
+			break;
+		}
+		case Instruction::AddrSpaceCast:
+		{
+			compileOperand(code, I.getOperand(0));
 			break;
 		}
 		case Instruction::Br:

--- a/llvm/lib/Transforms/Instrumentation/InstrProfiling.cpp
+++ b/llvm/lib/Transforms/Instrumentation/InstrProfiling.cpp
@@ -1015,7 +1015,7 @@ InstrProfiling::getOrCreateRegionCounters(InstrProfInstBase *Inc) {
   auto *DataTy = StructType::get(Ctx, makeArrayRef(DataTypes));
 
   Constant *FunctionAddr = shouldRecordFunctionAddr(Fn)
-                               ? ConstantExpr::getBitCast(Fn, Int8PtrTy)
+                               ? ConstantExpr::getPointerBitCastOrAddrSpaceCast(Fn, Int8PtrTy)
                                : ConstantPointerNull::get(Int8PtrTy);
 
   Constant *Int16ArrayVals[IPVK_Last + 1];

--- a/llvm/lib/Transforms/Scalar/SROA.cpp
+++ b/llvm/lib/Transforms/Scalar/SROA.cpp
@@ -2576,7 +2576,7 @@ private:
     assert(NewBeginOffset==NewAllocaBeginOffset);
     while(1)
     {
-      Value *RetPtr = getAdjustedPtr(IRB, DL, BasePtr, Ty, BaseOffset, TargetTy->getPointerTo(), TargetTy,
+      Value *RetPtr = getAdjustedPtr(IRB, DL, BasePtr, Ty, BaseOffset, TargetTy->getPointerTo(BasePtr->getType()->getPointerAddressSpace()), TargetTy,
                                 BasePtr->getName() + ".");
       if (RetPtr)
         return RetPtr;


### PR DESCRIPTION
- **feat: Add Cheerp LLVM address spaces, and map the clang ones to them**
- **ast: add function to deduce the Cheerp AS for a type**
- **cheerp: add getCheerpFunctionAS helper**
- **CallConstructors: Create argc/argv allocas in the correct AS**
- **CallConstructors: put null env alloca in the correct AS**
- **Add address space to jump table array**
- **GDA: memset/memcpy/memmove are not defined anymore in genericjs stdlibs**
- **fix(SROA): propagate base ptr address space**
- **WasmWriter: handle AS cast as nop**
- **profiling: allow addrspace cast of function pointers**
- **LowerGlobalDestructors: strip casts when getting a destructor function**
