### PR TITLE
GDA: memset/memcpy/memmove are not defined anymore in genericjs stdlibs

### DIFF
--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -21149,7 +21149,8 @@ void Sema::CheckCheerpFFICall(const FunctionDecl* Parent, const FunctionDecl* FD
   if (FDecl->getBuiltinID() == Builtin::BImemcpy ||
       FDecl->getBuiltinID() == Builtin::BImemmove ||
       FDecl->getBuiltinID() == Builtin::BImemset ||
-      FDecl->getBuiltinID() == Builtin::BIrealloc)
+      FDecl->getBuiltinID() == Builtin::BIrealloc ||
+      FDecl->getBuiltinID() == Builtin::BIfree)
     return;
   if (Parent->hasAttr<GenericJSAttr>() && FDecl->hasAttr<AsmJSAttr>()) {
     auto p = FDecl->parameters().begin();

--- a/llvm/lib/CheerpUtils/GlobalDepsAnalyzer.cpp
+++ b/llvm/lib/CheerpUtils/GlobalDepsAnalyzer.cpp
@@ -1474,11 +1474,11 @@ void GlobalDepsAnalyzer::visitFunction(const Function* F, VisitedSet& visited)
 						asmJSImportedFunctions.insert(calledFunc);
 				}
 				else if (calledFunc->getIntrinsicID() == Intrinsic::memset)
-					extendLifetime(module->getFunction("memset"));
+					extendLifetimeIfPresent(module->getFunction("memset"));
 				else if (calledFunc->getIntrinsicID() == Intrinsic::memcpy)
-					extendLifetime(module->getFunction("memcpy"));
+					extendLifetimeIfPresent(module->getFunction("memcpy"));
 				else if (calledFunc->getIntrinsicID() == Intrinsic::memmove)
-					extendLifetime(module->getFunction("memmove"));
+					extendLifetimeIfPresent(module->getFunction("memmove"));
 			}
 		}
 	


### PR DESCRIPTION
paired with https://github.com/leaningtech/cheerp-musl/pull/37