### PR TITLE
threads: rename workerEntry to __startThread and adjust signature.

### DIFF
--- a/llvm/lib/CheerpWriter/CheerpWriter.cpp
+++ b/llvm/lib/CheerpWriter/CheerpWriter.cpp
@@ -7441,9 +7441,8 @@ void CheerpWriter::compileWorkerMainScript()
 	// This helper is always available when emitting non-standalone Wasm with threading enabled
 	llvm::Function* setStack = module.getFunction("__setStackPtr");
 	stream << namegen.getName(setStack, 0) << "(" << threadObject << ".stack);" << NewLine;
-	stream << "workerEntry(" << threadObject << ".tls, " << threadObject << ".func, ";
-	stream << threadObject << ".args, " << threadObject << ".tid, ";
-	stream << threadObject << ".ctid);" << NewLine;
+	stream << "__startThread(" << threadObject << ".func, ";
+	stream << threadObject << ".args, " << threadObject << ".tls);" << NewLine;
 	stream << "}).catch(e=>{" << NewLine;
 	stream << "if(e!=='LeakUtilityThread'&&e!=='ThreadExit'){" << NewLine;
 	stream << "throw(e);" << NewLine;


### PR DESCRIPTION
This function is now defined both in cheerp-musl and cheerp-libs, and
all threaded targets use it.
